### PR TITLE
implement proper reconciliation loop for RoleBindings and ClusterRoleBindings

### DIFF
--- a/test/test-setup.yaml
+++ b/test/test-setup.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: dev
+  name: developer
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: dev
+  name: tester
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]

--- a/test/test-user-jane-1.yaml
+++ b/test/test-user-jane-1.yaml
@@ -7,5 +7,4 @@ spec:
     - namespace: dev
       existingRole: developer
   clusterRoles:
-    - existingClusterRole: view
-  expiry: 7d
+    - existingClusterRole: edit

--- a/test/test-user-jane-2.yaml
+++ b/test/test-user-jane-2.yaml
@@ -1,0 +1,10 @@
+apiVersion: auth.openkube.io/v1alpha1
+kind: User
+metadata:
+  name: jane
+spec:
+  roles:
+    - namespace: dev
+      existingRole: tester
+  clusterRoles:
+    - existingClusterRole: view


### PR DESCRIPTION
feat: implement proper reconciliation loop for RoleBindings and ClusterRoleBindings

- Add reconcileRoleBindings() method to manage namespace-scoped role bindings lifecycle
- Add reconcileClusterRoleBindings() method to manage cluster-wide role bindings lifecycle
- Implement proper desired vs actual state comparison to prevent resource accumulation
- Add OwnerReferences to enable automatic cleanup when User resources are deleted
- Add resource watching in SetupWithManager for RoleBindings, ClusterRoleBindings, ServiceAccounts, and Secrets
- Add roleBindingMatches() and clusterRoleBindingMatches() helper functions for state comparison
- Fix issue where updating User spec would create duplicate bindings instead of replacing old ones

This ensures continuous monitoring and enforcement of user permissions by:
1. Comparing desired state (from User spec) with actual state (existing resources)
2. Creating new resources as needed
3. Updating existing resources if they differ from desired state
4. Deleting outdated resources that are no longer desired

Fixes #1 