### PR TITLE
remove automatic namespace creation for GitOps compliance

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,14 +24,6 @@ rules:
   - ""
   resources:
   - namespaces
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - get

--- a/helm/kubeuser/README.md
+++ b/helm/kubeuser/README.md
@@ -16,24 +16,29 @@ This Helm chart deploys the KubeUser operator, a Kubernetes-native user manageme
 # Add the chart repository (if published)
 helm repo add kubeuser https://charts.example.com/kubeuser
 
-# Install with default values
-helm install kubeuser ./helm/kubeuser
+# Install with automatic namespace creation (recommended)
+helm install kubeuser ./helm/kubeuser --create-namespace -n kubeuser
 
-# Install with custom namespace (following user preference)
-helm install kubeuser ./helm/kubeuser \
-  --set global.namespace=kubeuser \
-  --set global.environment=test \
-  --set global.nameSuffix=-kubeuser
+# Or install into existing namespace
+helm install kubeuser ./helm/kubeuser -n existing-namespace
 ```
+
+**Important**: 
+- Everything (controller + user secrets) goes in the same namespace specified by `-n`
+- Use `--create-namespace` for new namespaces or ensure the namespace exists first
 
 ### Custom Installation
 
 ```bash
-# Install with custom configuration
+# Install with custom configuration and namespace creation
 helm install kubeuser ./helm/kubeuser \
+  --create-namespace -n kubeuser \
   --set image.tag=v0.2.0 \
   --set webhook.enabled=true \
-  --set metrics.enabled=true \
+  --set metrics.enabled=true
+
+# Install into existing namespace
+helm install kubeuser ./helm/kubeuser -n my-existing-namespace
 ```
 
 ## Configuration
@@ -42,13 +47,10 @@ The following table lists the configurable parameters and their default values:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `global.namespace` | Target namespace for deployment | `kubeuser` |
-| `global.environment` | Environment label | `test` |
-| `global.nameSuffix` | Suffix for namespace name | `-kubeuser` |
-| `image.repository` | Controller image repository | `kubeuser-controller` |
+| `image.repository` | Controller image repository | `ghcr.io/openkube-hub/kubeuser-controller` |
 | `image.tag` | Controller image tag | `latest` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `replicaCount` | Number of controller replicas | `1` |
+| `replicaCount` | Number of controller replicas | `2` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |
 | `resources.requests.cpu` | CPU request | `10m` |

--- a/helm/kubeuser/templates/NOTES.txt
+++ b/helm/kubeuser/templates/NOTES.txt
@@ -2,7 +2,7 @@
 
 🚀 Deployment Details:
    - Release Name: {{ .Release.Name }}
-   - Namespace: {{ include "kubeuser.namespace" . }}
+   - Namespace: {{ .Release.Namespace }}
    - Chart Version: {{ .Chart.Version }}
    - App Version: {{ .Chart.AppVersion }}
 
@@ -23,7 +23,7 @@
 📋 Next Steps:
 
 1. Check the operator deployment status:
-   kubectl get deployment {{ include "kubeuser.fullname" . }}-controller-manager -n {{ include "kubeuser.namespace" . }}
+   kubectl get deployment {{ include "kubeuser.fullname" . }}-controller-manager -n {{ .Release.Namespace }}
 
 2. Verify the CRD is installed:
    kubectl get crd users.auth.openkube.io

--- a/helm/kubeuser/templates/_helpers.tpl
+++ b/helm/kubeuser/templates/_helpers.tpl
@@ -65,17 +65,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the namespace to use (with suffix if specified)
-*/}}
-{{- define "kubeuser.namespace" -}}
-{{- if .Values.global.nameSuffix }}
-{{- printf "%s%s" .Values.global.namespace .Values.global.nameSuffix }}
-{{- else }}
-{{- .Values.global.namespace }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create manager labels for controller-manager
 */}}
 {{- define "kubeuser.managerLabels" -}}

--- a/helm/kubeuser/templates/deployment.yaml
+++ b/helm/kubeuser/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubeuser.fullname" . }}-controller-manager
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.managerLabels" . | nindent 4 }}
   {{- with .Values.podLabels }}
@@ -47,7 +47,7 @@ spec:
         - name: WEBHOOK_SERVICE_NAME
           value: {{ include "kubeuser.fullname" . }}-webhook-service
         - name: KUBEUSER_NAMESPACE
-          value: {{ include "kubeuser.namespace" . }}
+          value: {{ .Release.Namespace }}
         {{- with .Values.env }}
         {{- range $key, $value := . }}
         - name: {{ $key }}

--- a/helm/kubeuser/templates/namespace.yaml
+++ b/helm/kubeuser/templates/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    {{- include "kubeuser.managerLabels" . | nindent 4 }}
-  name: {{ include "kubeuser.namespace" . }}

--- a/helm/kubeuser/templates/rbac.yaml
+++ b/helm/kubeuser/templates/rbac.yaml
@@ -161,7 +161,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubeuser.serviceAccountName" . }}
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 
 ---
 # permissions to do leader election.
@@ -169,7 +169,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kubeuser.fullname" . }}-leader-election-role
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.labels" . | nindent 4 }}
 rules:
@@ -210,7 +210,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kubeuser.fullname" . }}-leader-election-rolebinding
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.labels" . | nindent 4 }}
 roleRef:
@@ -220,7 +220,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubeuser.serviceAccountName" . }}
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 
 {{- if .Values.metrics.enabled }}
 ---
@@ -258,7 +258,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubeuser.serviceAccountName" . }}
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/kubeuser/templates/service.yaml
+++ b/helm/kubeuser/templates/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kubeuser.fullname" . }}-webhook-service
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kubeuser.fullname" . }}-metrics-service
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.managerLabels" . | nindent 4 }}
 spec:

--- a/helm/kubeuser/templates/serviceaccount.yaml
+++ b/helm/kubeuser/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubeuser.serviceAccountName" . }}
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/kubeuser/templates/webhook-cert-manager.yaml
+++ b/helm/kubeuser/templates/webhook-cert-manager.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "kubeuser.fullname" . }}-webhook-issuer
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.labels" . | nindent 4 }}
 spec:
@@ -16,7 +16,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "kubeuser.fullname" . }}-webhook-cert
-  namespace: {{ include "kubeuser.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeuser.labels" . | nindent 4 }}
 spec:
@@ -30,9 +30,9 @@ spec:
   # DNS names that the certificate should be valid for
   dnsNames:
   - {{ include "kubeuser.fullname" . }}-webhook-service
-  - {{ include "kubeuser.fullname" . }}-webhook-service.{{ include "kubeuser.namespace" . }}
-  - {{ include "kubeuser.fullname" . }}-webhook-service.{{ include "kubeuser.namespace" . }}.svc
-  - {{ include "kubeuser.fullname" . }}-webhook-service.{{ include "kubeuser.namespace" . }}.svc.cluster.local
+  - {{ include "kubeuser.fullname" . }}-webhook-service.{{ .Release.Namespace }}
+  - {{ include "kubeuser.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ include "kubeuser.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   # Duration and renewal
   duration: {{ .Values.webhook.certManager.duration | default "8760h" }}
   renewBefore: {{ .Values.webhook.certManager.renewBefore | default "2160h" }}

--- a/helm/kubeuser/templates/webhook-csr.yaml
+++ b/helm/kubeuser/templates/webhook-csr.yaml
@@ -9,14 +9,14 @@ metadata:
     {{- include "kubeuser.labels" . | nindent 4 }}
   annotations:
     # cert-manager will inject the CA bundle automatically
-    cert-manager.io/inject-ca-from: {{ include "kubeuser.namespace" . }}/{{ include "kubeuser.fullname" . }}-webhook-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kubeuser.fullname" . }}-webhook-cert
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
       name: {{ include "kubeuser.fullname" . }}-webhook-service
-      namespace: {{ include "kubeuser.namespace" . }}
+      namespace: {{ .Release.Namespace }}
       path: /validate-auth-openkube-io-v1alpha1-user
     # caBundle will be injected automatically by cert-manager
   failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}

--- a/helm/kubeuser/values.yaml
+++ b/helm/kubeuser/values.yaml
@@ -9,8 +9,7 @@ fullnameOverride: ""
 
 # Global settings
 global:
-  # Namespace configuration
-  namespace: kubeuser
+  # Common suffix for resource names (optional)
   nameSuffix: ""
 
 # Image configuration
@@ -111,6 +110,7 @@ metrics:
 
 # Environment variables
 env:
+  # Kubernetes API server endpoint
   KUBERNETES_API_SERVER: "https://kubernetes.default.svc"
 
 # RBAC configuration


### PR DESCRIPTION
fix: remove auto namespace creation for GitOps compliance

- Controller no longer creates namespaces automatically
- Simplified Helm chart to use single Release.Namespace
- Added clear error when target namespace missing
- Fixed all template namespace references

BREAKING CHANGE: Use --create-namespace or pre-create namespace

Fixes #23