### PR TITLE
escalation permission removed from controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -110,7 +110,6 @@ rules:
   - bind
   - create
   - delete
-  - escalate
   - get
   - list
   - patch
@@ -123,7 +122,6 @@ rules:
   - roles
   verbs:
   - bind
-  - escalate
   - get
   - list
   - watch

--- a/helm/kubeuser/templates/rbac.yaml
+++ b/helm/kubeuser/templates/rbac.yaml
@@ -118,7 +118,6 @@ rules:
   - update
   - watch
   - bind
-  - escalate
 # Grant permissions to bind any role/clusterrole (needed for user management)
 - apiGroups:
   - rbac.authorization.k8s.io
@@ -127,7 +126,6 @@ rules:
   - clusterroles
   verbs:
   - bind
-  - escalate
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -138,7 +136,6 @@ rules:
   - list
   - watch
   - bind
-  - escalate
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -62,9 +62,9 @@ type UserReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods;replicasets,verbs=get;list;watch;create;update;patch;delete
 // Apps resources
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;list;watch;create;update;patch;delete
-// RBAC resources with bind/escalate permissions
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;clusterroles,verbs=get;list;watch;bind;escalate
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind;escalate
+// RBAC resources with bind permission
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;clusterroles,verbs=get;list;watch;bind
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind
 // CSR resources
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests/approval,verbs=update


### PR DESCRIPTION
based on k8s docs
The bind verb on roles and clusterroles allows a subject to bind that role to subjects. This does not require the actor to possess all the permissions in the role being bound.

fixes #26 