### PR TITLE
fix(rbac): drop unused scaffold permissions from manager and chart roles

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,10 +8,7 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
-  - replicasets
   - secrets
-  - serviceaccounts
   verbs:
   - create
   - delete
@@ -36,19 +33,6 @@ rules:
   verbs:
   - get
   - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - auth.openkube.io
   resources:

--- a/helm/kubeuser/templates/rbac.yaml
+++ b/helm/kubeuser/templates/rbac.yaml
@@ -12,7 +12,6 @@ rules:
   resources:
   - configmaps
   - secrets
-  - serviceaccounts
   verbs:
   - create
   - delete
@@ -32,36 +31,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - replicasets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - auth.openkube.io

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -51,12 +51,9 @@ type UserReconciler struct {
 // +kubebuilder:rbac:groups=auth.openkube.io,resources=users/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=auth.openkube.io,resources=users/finalizers,verbs=update
 // Core resources
-// +kubebuilder:rbac:groups="",resources=configmaps;secrets;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=pods;replicasets,verbs=get;list;watch;create;update;patch;delete
-// Apps resources
-// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;list;watch;create;update;patch;delete
 // RBAC resources with bind permission
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;clusterroles,verbs=get;list;watch;bind
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind


### PR DESCRIPTION
## Summary

  The manager `ClusterRole` granted CRUD over four resources the controller never accesses — `pods`, `replicasets` (both core and `apps` API groups),
  `deployments`, and `serviceaccounts`. These were kubebuilder scaffold leftovers; pruning them brings the role into line with least-privilege and
  unblocks CIS Kubernetes Benchmark and Gatekeeper RBAC audits.

  This PR removes them from both the kubebuilder source-of-truth (`internal/controller/user_controller.go`) and the Helm chart's hand-maintained
  parallel role (`helm/kubeuser/templates/rbac.yaml`), so deployments via kustomize **or** Helm now ship with the same minimal permission set.

  Closes #69

  ## Changes

  - **`internal/controller/user_controller.go`** — Removed `serviceaccounts` from the core `+kubebuilder:rbac` marker, and deleted the two scaffold
  marker lines for `pods;replicasets` (core) and `deployments;replicasets` (apps).
  - **`config/rbac/role.yaml`** — Regenerated via `make manifests`. Not hand-edited.
  - **`helm/kubeuser/templates/rbac.yaml`** — Hand-maintained chart-side `ClusterRole`; removed the same four resources to keep parity with the
  kubebuilder-generated role.

  The resulting manager `ClusterRole` retains only API surface the controller actually exercises: `configmaps`, `secrets`, `namespaces`, `services`,
  `users` (+ `users/status`, `users/finalizers`), `certificatesigningrequests` (+ `approval`, `signers`), `rolebindings` / `clusterrolebindings`,
  `roles` / `clusterroles`, and `validatingwebhookconfigurations`.

  ## Verification

  - [x] `make manifests` is idempotent — re-running produces no further diff.
  - [x] `make test` green (unit + envtest against a real `kube-apiserver`).
  - [x] `make test-e2e` green — 2/2 specs passed in 204s. The controller deploys with its `ServiceAccount` bound to the pruned `ClusterRole` and
  reconciles `User` resources end-to-end without 403s.
  - [x] Helm chart smoke-tested in an isolated kind cluster: `helm install` succeeds, rendered `ClusterRole` confirmed not to contain any of the four
  pruned resources, sample `User` CR reaches `Status.Phase: Active`, and the expected RoleBindings / ClusterRoleBindings / kubeconfig Secret are all
  created.
  - [x] Confirmed via grep that no Go code under `internal/` or `cmd/` imports `apps/v1` or references `corev1.ServiceAccount{}` / `corev1.Pod{}` /
  `appsv1.Deployment{}`. The only matches in `test/e2e/` are `kubectl` shell calls inspecting the controller-manager pod, not API-client operations.
  ## Out of scope / noted but not changed

  - **Chart and kubebuilder source diverge on webhook configs.** While editing `helm/kubeuser/templates/rbac.yaml`, I noticed the chart grants `get` /
   `patch` on **both** `mutatingwebhookconfigurations` and `validatingwebhookconfigurations`, whereas `config/rbac/role.yaml` (and the marker at
  `internal/controller/user_controller.go:65`) only grant it on `validatingwebhookconfigurations`. This is pre-existing drift unrelated to #69, and
  the question of whether the controller legitimately needs to patch mutating webhook configs deserves its own discussion. Happy to file a follow-up
  issue if maintainers prefer.

  ## Risk

  Low. No new permissions granted, no controller logic touched, no API changes. Existing deployments retain the broader role until the new manifest is applied; reapplying narrows the role with no other side effects.