### PR TITLE
fix: default --leader-elect to true to prevent split-brain HA

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,9 +68,10 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
+		"Enable leader election for controller manager. Defaults to true so HA "+
+			"deployments (replicas > 1) elect a single active manager."+
+			"Pass --leader-elect=false for single-replica deployments.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")


### PR DESCRIPTION
## Summary

  `enableLeaderElection` defaulted to `false`, so any HA deployment with `replicas > 1` that didn't explicitly pass `--leader-elect=true` ran multiple active controllers in parallel — causing duplicate CSR rotations and conflicting Secret writes. The chart ships `replicas: 2`, so this was a real footgun for anyone scaling the manager Deployment without reading the source.

  This PR flips the default to `true` and rewrites the help text to advertise the new default and document `--leader-elect=false` as the single-replica opt-out.

  Closes #65

  ## Changes

  - **`cmd/main.go:71`** — Default for `--leader-elect` flipped from `false` to `true`. Help text updated to describe the new default and the opt-out path.

  ## Verification

  - [x] `make test` green.
  - [x]  `make test-e2e` green
  - [x] **HA scenario (`replicas: 2`, default `--leader-elect=true`).** Both pods reach `Running`. Exactly one `coordination.k8s.io/Lease` exists with one `holderIdentity` matching one of the pod names; only the leader pod logs `successfully acquired lease`, the other stays standby.
  - [x] **Single-replica scenario with opt-out (`replicas: 1`, `--leader-elect=false`).** Single pod reaches `Running` with the expected args (`--leader-elect=false` confirmed via `kubectl get pod -o jsonpath`). No `Lease` object is created. A sample `User` CR still reconciles to `Status.Phase: Active`, confirming the opt-out path doesn't break functionality.

  ## Risk

   Low. The change corrects an active correctness bug for HA users without affecting deployments that already pass `--leader-elect=true` explicitly (the chart's `manager.yaml` and `values.yaml` already do). Single-replica deployments that don't override the flag now use leader election by default; the documented opt-out via `--leader-elect=false` is for users who want to skip the lease entirely.