### PR TITLE
Fix/issue 59 zap production default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,9 +83,7 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -215,8 +215,8 @@ var _ = Describe("Manager", Ordered, func() {
 				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
-					"Metrics server not yet started")
+				g.Expect(output).To(ContainSubstring(`"msg":"Serving metrics server"`),
+      				"Metrics server not yet started")
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
 


### PR DESCRIPTION
## Summary

  `cmd/main.go:86-88` initialised `zap.Options` with `Development: true` hardcoded. Development mode uses the console encoder (non-JSON) and attaches a stack trace to every Warn/Error log, breaking structured log aggregation in Loki, Splunk, Datadog, and similar systems, and inflating log volume with stack traces on routine retryable errors.

  This PR removes the hardcoded field so production deployments get JSON-encoded logs by default. The existing `--zap-devel` CLI flag (registered via `opts.BindFlags`) continues to work and is the supported opt-in for local debugging.

  Closes #59

  ## Changes

  - **`cmd/main.go:86-88`** — Removed `Development: true` from the `zap.Options` struct literal. The field's zero value (`false`) is now the default; `--zap-devel=true` remains available for local dev sessions.
  - **`test/e2e/e2e_test.go:218`** — Updated the metrics-server log assertion to match the new JSON encoder output. The previous assertion looked for the tab-separated console-format substring `controller-runtime.metrics\tServing metrics server`, which only existed because of the bug fixed above. Now matches `"msg":"Serving metrics server"` against the JSON line.

  ## Verification

  - [x] `make manifests` green.
  - [x] `make test` green.
  - [x] `make test-e2e` green (2/2 specs pass on a fresh kind cluster).
  - [x] Built image, deployed via Helm chart in kind, observed pod logs are JSON-encoded (`{"level":"...","ts":"...","msg":"..."}`) by default — confirmed format change.
  - [x] Re-deployed with `--zap-devel=true` overriding `manager.args`; logs reverted to console format. Confirms the flag still works as the documented dev opt-in.

  ## Risk

  Low. No behavior change for callers that already passed `--zap-devel=false`. Production deployments stop emitting console-formatted logs and Warn-level stack traces which is the bug being fixed. The e2e assertion update is mechanically tied to the encoder change.