### PR TITLE
fix(cleanup): delete rotation artifacts in user finalizer (#53)                                                                                                        

### DIFF
--- a/internal/controller/cleanup/finalizers.go
+++ b/internal/controller/cleanup/finalizers.go
@@ -18,45 +18,89 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
 	UserFinalizer = "auth.openkube.io/finalizer"
+
+	// userLabel selects all operator-managed resources for a given User.
+	userLabel = "auth.openkube.io/user"
 )
 
-// CleanupUserResources deletes all resources related to the user.
+// CleanupUserResources deletes resources owned by the user. Best-effort:
+// per-resource failures are logged but never block finalizer removal.
 func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alpha1.User) {
 	// Finalizer cleanup must complete promptly to unblock the deletion path.
 	// The caller's context may already be bounded; this adds a firm local ceiling.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	logger := logf.FromContext(ctx).WithName("cleanup")
 	username := user.Name
 	userNamespace := helpers.GetKubeUserNamespace()
+	selector := client.MatchingLabels{userLabel: username}
 
-	// Delete fixed resources
+	// Delete fixed-name resources (steady-state secrets and initial CSR).
 	fixed := []client.Object{
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-key", username), Namespace: userNamespace}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-kubeconfig", username), Namespace: userNamespace}},
 		&certv1.CertificateSigningRequest{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-csr", username)}},
 	}
 	for _, obj := range fixed {
-		_ = r.Delete(ctx, obj)
-	}
-
-	// Delete RoleBindings across namespaces
-	var rbs rbacv1.RoleBindingList
-	if err := r.List(ctx, &rbs, client.MatchingLabels{"auth.openkube.io/user": username}); err == nil {
-		for _, rb := range rbs.Items {
-			_ = r.Delete(ctx, &rb)
+		if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "failed to delete fixed resource",
+				"kind", fmt.Sprintf("%T", obj), "name", obj.GetName(), "namespace", obj.GetNamespace())
 		}
 	}
 
-	// Delete ClusterRoleBindings
+	// Delete user-labelled Secrets in the operator namespace (rotation shadow).
+	var secrets corev1.SecretList
+	if err := r.List(ctx, &secrets, selector, client.InNamespace(userNamespace)); err != nil {
+		logger.Error(err, "failed to list user-labelled secrets", "namespace", userNamespace)
+	} else {
+		for i := range secrets.Items {
+			if err := r.Delete(ctx, &secrets.Items[i]); client.IgnoreNotFound(err) != nil {
+				logger.Error(err, "failed to delete labelled secret", "name", secrets.Items[i].Name)
+			}
+		}
+	}
+
+	// Delete user-labelled CSRs cluster-wide; closes the orphan window
+	// where a signed renewal cert could outlive the User.
+	var csrs certv1.CertificateSigningRequestList
+	if err := r.List(ctx, &csrs, selector); err != nil {
+		logger.Error(err, "failed to list user-labelled CSRs")
+	} else {
+		for i := range csrs.Items {
+			if err := r.Delete(ctx, &csrs.Items[i]); client.IgnoreNotFound(err) != nil {
+				logger.Error(err, "failed to delete labelled CSR", "name", csrs.Items[i].Name)
+			}
+		}
+	}
+
+	// Delete RoleBindings across namespaces.
+	var rbs rbacv1.RoleBindingList
+	if err := r.List(ctx, &rbs, selector); err != nil {
+		logger.Error(err, "failed to list user RoleBindings")
+	} else {
+		for i := range rbs.Items {
+			if err := r.Delete(ctx, &rbs.Items[i]); client.IgnoreNotFound(err) != nil {
+				logger.Error(err, "failed to delete RoleBinding",
+					"name", rbs.Items[i].Name, "namespace", rbs.Items[i].Namespace)
+			}
+		}
+	}
+
+	// Delete ClusterRoleBindings.
 	var crbs rbacv1.ClusterRoleBindingList
-	if err := r.List(ctx, &crbs, client.MatchingLabels{"auth.openkube.io/user": username}); err == nil {
-		for _, crb := range crbs.Items {
-			_ = r.Delete(ctx, &crb)
+	if err := r.List(ctx, &crbs, selector); err != nil {
+		logger.Error(err, "failed to list user ClusterRoleBindings")
+	} else {
+		for i := range crbs.Items {
+			if err := r.Delete(ctx, &crbs.Items[i]); client.IgnoreNotFound(err) != nil {
+				logger.Error(err, "failed to delete ClusterRoleBinding", "name", crbs.Items[i].Name)
+			}
 		}
 	}
 }

--- a/internal/controller/cleanup/finalizers.go
+++ b/internal/controller/cleanup/finalizers.go
@@ -41,16 +41,16 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 	userNamespace := helpers.GetKubeUserNamespace()
 	selector := client.MatchingLabels{userLabel: username}
 
-	// Delete fixed-name resources (steady-state secrets and initial CSR).
+	// Delete steady-state secrets by name. They aren't labelled at creation,
+	// so the label-selector passes below won't catch them.
 	fixed := []client.Object{
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-key", username), Namespace: userNamespace}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-kubeconfig", username), Namespace: userNamespace}},
-		&certv1.CertificateSigningRequest{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-csr", username)}},
 	}
 	for _, obj := range fixed {
 		if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
 			logger.Error(err, "failed to delete fixed resource",
-				"kind", fmt.Sprintf("%T", obj), "name", obj.GetName(), "namespace", obj.GetNamespace())
+				"kind", "Secret", "name", obj.GetName(), "namespace", obj.GetNamespace())
 		}
 	}
 

--- a/internal/controller/cleanup/finalizers_test.go
+++ b/internal/controller/cleanup/finalizers_test.go
@@ -48,9 +48,13 @@ func TestCleanupUserResources_DeletesRotationArtifacts(t *testing.T) {
 		Labels: map[string]string{"auth.openkube.io/user": "bob"},
 	}}
 
+	aliceKey := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-key", Namespace: "kubeuser"}}
+	aliceKubeconfig := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-kubeconfig", Namespace: "kubeuser"}}
+	bobKey := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bob-key", Namespace: "kubeuser"}}
+
 	cli := fake.NewClientBuilder().
 		WithScheme(newScheme(t)).
-		WithObjects(user, shadow, renewalCSR, otherShadow).
+		WithObjects(user, shadow, renewalCSR, otherShadow, aliceKey, aliceKubeconfig, bobKey).
 		Build()
 
 	CleanupUserResources(context.Background(), cli, user)
@@ -71,6 +75,10 @@ func TestCleanupUserResources_DeletesRotationArtifacts(t *testing.T) {
 
 	mustNotFound("shadow secret", &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-rotation-temp", Namespace: "kubeuser"}})
 	mustNotFound("renewal csr", &certv1.CertificateSigningRequest{ObjectMeta: metav1.ObjectMeta{Name: "alice-renewal-uid12345"}})
+	mustNotFound("alice-key", &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-key", Namespace: "kubeuser"}})
+	mustNotFound("alice-kubeconfig", &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-kubeconfig", Namespace: "kubeuser"}})
+	mustExist("bob-key (different user, must survive)",
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bob-key", Namespace: "kubeuser"}})
 	mustExist("bob's shadow secret (different user, must survive)",
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bob-rotation-temp", Namespace: "kubeuser"}})
 }

--- a/internal/controller/cleanup/finalizers_test.go
+++ b/internal/controller/cleanup/finalizers_test.go
@@ -1,0 +1,76 @@
+package cleanup
+
+import (
+	"context"
+	"testing"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	certv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme, certv1.AddToScheme, rbacv1.AddToScheme, authv1alpha1.AddToScheme,
+	} {
+		if err := add(s); err != nil {
+			t.Fatalf("scheme: %v", err)
+		}
+	}
+	return s
+}
+
+// Regression test for issue #53: rotation artifacts must be deleted by the
+// finalizer, not left to garbage collection.
+func TestCleanupUserResources_DeletesRotationArtifacts(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	user := &authv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: "alice", UID: "uid-123"}}
+	shadow := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: "alice-rotation-temp", Namespace: "kubeuser",
+		Labels: map[string]string{"auth.openkube.io/user": "alice"},
+	}}
+	renewalCSR := &certv1.CertificateSigningRequest{ObjectMeta: metav1.ObjectMeta{
+		Name:   "alice-renewal-uid12345",
+		Labels: map[string]string{"auth.openkube.io/user": "alice"},
+	}}
+	// Resource for a different user must survive — proves the selector is correct.
+	otherShadow := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: "bob-rotation-temp", Namespace: "kubeuser",
+		Labels: map[string]string{"auth.openkube.io/user": "bob"},
+	}}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(user, shadow, renewalCSR, otherShadow).
+		Build()
+
+	CleanupUserResources(context.Background(), cli, user)
+
+	mustNotFound := func(name string, obj client.Object) {
+		t.Helper()
+		err := cli.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+		if !apierrors.IsNotFound(err) {
+			t.Errorf("%s: expected NotFound, got %v", name, err)
+		}
+	}
+	mustExist := func(name string, obj client.Object) {
+		t.Helper()
+		if err := cli.Get(context.Background(), client.ObjectKeyFromObject(obj), obj); err != nil {
+			t.Errorf("%s: expected to still exist, got %v", name, err)
+		}
+	}
+
+	mustNotFound("shadow secret", &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-rotation-temp", Namespace: "kubeuser"}})
+	mustNotFound("renewal csr", &certv1.CertificateSigningRequest{ObjectMeta: metav1.ObjectMeta{Name: "alice-renewal-uid12345"}})
+	mustExist("bob's shadow secret (different user, must survive)",
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bob-rotation-temp", Namespace: "kubeuser"}})
+}


### PR DESCRIPTION
## Summary      
                                                                                                        
`CleanupUserResources` at `internal/controller/cleanup/finalizers.go:38-45` deleted only three fixed-name resources (`{u}-key`, `{u}-kubeconfig`, `{u}-csr`) and missed the rotation artifacts created mid-flip: `{u}-rotation-temp` (shadow secret holding a freshly generated private key, `rotation.go:346`) and `{u}-renewal-{uid8}` (CSR which may already carry a signed client certificate, `rotation.go:421`). Both survived the finalizer and were only cleaned by Kubernetes garbage collection chasing the owner reference — async, best-effort, ineffective if the ownerRef is missing. During the window the API server still trusted any signed renewal cert. If a User was recreated with the same name before GC swept, `getShadowSecret` at `rotation.go:325` (matches on `Name + Namespace` only) caused the new reconciler to adopt the previous user's shadow secret.

This PR adds label-selector deletes for Secrets and CertificateSigningRequests carrying `auth.openkube.io/user=<name>`, mirroring the existing RoleBinding / ClusterRoleBinding cleanup pattern.cAdds a regression test.                                                                                
                
Closes #53

## Changes

- **`internal/controller/cleanup/finalizers.go`** — Added label-selector delete passes for user-labelled
 Secrets (in the operator namespace) and cluster-scoped CSRs. Wrapped existing deletes with
`client.IgnoreNotFound` and structured `logf` logging. Hoisted `auth.openkube.io/user` into a           
`userLabel` const. The fixed-name pass is retained for `{u}-key` and `{u}-kubeconfig` only — they are
not labelled at creation, so the label-selector pass cannot reach them. `{u}-csr` IS labelled at
creation (`certs.go:268`) and is now deleted exclusively by the CSR selector pass, avoiding a redundantc404.
- **`internal/controller/cleanup/finalizers_test.go`** — New. Asserts alice's shadow secret, renewal 
CSR, `{u}-key`, and `{u}-kubeconfig` are deleted; bob's shadow secret and `bob-key` survive  proves selector scoping for both labelled and fixed-name passes.
                                                                                                        
## Review fixups (addressed in follow-up commits)
                                                                                                        
- Fixed misleading rationale in the in-code comment and PR description: only `{u}-key` and `{u}-kubeconfig` are unlabelled at creation.                                                            
- Removed `{u}-csr` from the fixed-name list; the CSR label-selector pass already covers it (was a redundant 404 per cleanup).                                                                             
- Replaced `fmt.Sprintf("%T", obj)` with a static `"Secret"` log key (was emitting pointer types like `*v1.Secret`).                                                                                          
- Extended the regression test to assert `{u}-key`, `{u}-kubeconfig` deletion and a `bob-key` survival check.                                                                                                  
                
## Verification                                                                                         
                
- [x] `make test` and `make lint` green; `gofmt -l` empty; `go vet` clean; `golangci-lint` reports `0 issues`.                                                                                                
- [x] **Reproduced pre-fix on a kind cluster.** Staged `alice-rotation-temp` and a signed `alice-renewal-{uid8}` **without `ownerReferences`** so K8s GC cannot mask the test. After User deletion both artifacts persisted at 33s and 63s post-delete; the renewal CSR's `status.certificate` parsed under `openssl x509` with `subject=CN=alice`.                                                           
- [x] **Confirmed post-fix on a fresh kind cluster.** `kind create cluster`, installed cert-manager,  `docker build --no-cache`, `kind load docker-image`, `helm install` with the new image tag. Verified running pod's `imageID` matches the rebuilt sha. Identical scenario to the pre-fix reproduction: both artifacts are `NotFound` immediately after `Successfully cleaned up and removed finalizer` is logged. Steady-state `{u}-key` / `{u}-kubeconfig` / `{u}-csr` continue to be deleted.
- [x] **Verified the two harm claims in Summary independently.** A signed renewal-style cert authenticates as `Username: alice` via `kubectl auth whoami` even with no User CR and no CSR backing it  confirms the API server trusts orphan signed certs based purely on CN + cluster CA. Then staged a leftover `alice-rotation-temp` (no ownerRef, `csr-name` pointing at a non-existent CSR) and created a new User alice with a different UID; on the next reconcile the controller logged `Shadow Secret found, ensuring Renewing state` and `Continuing rotation from Shadow Secret csrName=alice-renewal-DEADBEEF` confirms `getShadowSecret` matches by Name+Namespace only.
- [x] **Controller logs verified JSON-encoded and structured** during cleanup; the new `cleanup` logger emits nothing on the happy path (silent-on-success, loud-on-failure design).                            
- [x] `make test-e2e` green.
                                                                                                        
## Risk         
                                                                                                        
Low. No CRD, RBAC, or signature changes. Manager `ClusterRole` already grants `secrets list;delete` and  `csrs list;delete` (`internal/controller/user_controller.go:54,61`); `make manifests` is a no-op. Selector is scoped to `auth.openkube.io/user=<this-user>` other users' resources are unaffected.  Strictly additive: previously-uncleaned rotation artifacts are now cleaned, everything else unchanged.  
            