### PR TITLE
ci: harden release workflow and fix Helm chart publishing

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,6 +1,9 @@
 # chart-releaser configuration
 # https://github.com/helm/chart-releaser
 
+# Release title format — just the version tag (e.g. v0.2.0).
+release-name-template: "v{{ .Version }}"
+
 # Generate release notes automatically from commits since the previous tag.
 generate-release-notes: true
 

--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,11 @@
+# chart-releaser configuration
+# https://github.com/helm/chart-releaser
+
+# Generate release notes automatically from commits since the previous tag.
+generate-release-notes: true
+
+# Push the updated index.yaml to the gh-pages branch after each release.
+push: true
+
+# Skip uploading chart tarballs that already exist in a GitHub Release.
+skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0   # required by chart-releaser to compare versions
-          persist-credentials: false
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,16 @@ jobs:
             yq -i ".appVersion = env(VERSION)" helm/kubeuser/Chart.yaml
             yq -i ".image.tag = env(VERSION)" helm/kubeuser/values.yaml
 
+      - name: Initialise gh-pages branch (first run only)
+        run: |
+          if ! git ls-remote --exit-code origin gh-pages; then
+            git checkout --orphan gh-pages
+            git reset --hard
+            git commit --allow-empty -m "Initialize GitHub Pages"
+            git push origin gh-pages
+            git checkout -
+          fi
+
       - name: Install Helm
         uses: azure/setup-helm@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/kubeuser-controller
 
 jobs:
   # --------------------------------------------------
@@ -39,10 +38,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set VERSION from tag
+      - name: Set VERSION and image name
         run: |
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$(echo '${{ github.repository_owner }}/kubeuser-controller' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,78 +4,113 @@ on:
   push:
     tags:
       - "v*.*.*"   # trigger on semantic version tags like v0.1.0
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.2.0)"
+        required: true
+
+# Deny all permissions by default; each job grants only what it needs.
+permissions: {}
+
+# One release at a time — never cancel an in-flight release.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/kubeuser-controller
 
 jobs:
-  release:
+  # --------------------------------------------------
+  # Job 1: Build and push controller image to GHCR
+  # --------------------------------------------------
+  release-controller:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write   # push to GHCR with built-in GITHUB_TOKEN
+
     steps:
-      # --------------------------
-      # Checkout repo
-      # --------------------------
       - name: Checkout code
         uses: actions/checkout@v4
-
-      # --------------------------
-      # Set version from tag
-      # --------------------------
-      - name: Set VERSION
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      # --------------------------
-      # Build & push controller Docker image
-      # --------------------------
-      - name: Log in to GHCR
-        run: echo "${{ secrets.ACTION_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Build and push controller
-        run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/kubeuser-controller:${VERSION} .
-          docker push ghcr.io/${{ github.repository_owner }}/kubeuser-controller:${VERSION}
-
-      # --------------------------
-      # Install Helm and yq
-      # --------------------------
-      - name: Install Helm and yq
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-          sudo apt-get update
-          sudo apt-get install -y jq
-          sudo snap install yq
-
-      # --------------------------
-      # Update Helm chart versions
-      # --------------------------
-      - name: Update Chart.yaml and values.yaml
-        run: |
-          yq -i ".version = env(VERSION)" helm/kubeuser/Chart.yaml
-          yq -i ".appVersion = env(VERSION)" helm/kubeuser/Chart.yaml
-          yq -i ".image.tag = env(VERSION)" helm/kubeuser/values.yaml
-
-      # --------------------------
-      # Package Helm chart
-      # --------------------------
-      - name: Package Helm chart
-        run: helm package helm/kubeuser -d charts-dist
-
-      # --------------------------
-      # Update Helm repository index
-      # --------------------------
-      - name: Update Helm repo index
-        run: |
-          mkdir -p charts-dist
-          if [ -f charts-dist/index.yaml ]; then
-            helm repo index charts-dist --merge charts-dist/index.yaml --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
-          else
-            helm repo index charts-dist --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
-          fi
-
-      # --------------------------
-      # Publish only Helm artifacts to gh-pages
-      # --------------------------
-      - name: Publish Helm charts to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.ACTION_PAT }}
-          publish_branch: gh-pages
-          publish_dir: charts-dist
+          persist-credentials: false
+
+      - name: Set VERSION from tag
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push controller image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # --------------------------------------------------
+  # Job 2: Package and release Helm chart
+  # Uses chart-releaser-action — stores each chart version
+  # as a GitHub Release asset, preserving full history.
+  # --------------------------------------------------
+  release-chart:
+    runs-on: ubuntu-latest
+    needs: release-controller
+
+    permissions:
+      contents: write   # create GitHub Releases and push to gh-pages
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # required by chart-releaser to compare versions
+          persist-credentials: false
+
+      - name: Configure Git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Set VERSION from tag
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Update chart version
+        uses: mikefarah/yq@v4
+        with:
+          cmd: |
+            yq -i ".version = env(VERSION)" helm/kubeuser/Chart.yaml
+            yq -i ".appVersion = env(VERSION)" helm/kubeuser/Chart.yaml
+            yq -i ".image.tag = env(VERSION)" helm/kubeuser/values.yaml
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint chart
+        run: helm lint helm/kubeuser
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: helm
+          config: .github/cr.yaml
+          skip_existing: true   # safe to re-run — skips already released versions
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,11 +102,12 @@ jobs:
       - name: Initialise gh-pages branch (first run only)
         run: |
           if ! git ls-remote --exit-code origin gh-pages; then
+            ORIG=$(git rev-parse HEAD)
             git checkout --orphan gh-pages
-            git reset --hard
+            git rm -rf . --quiet
             git commit --allow-empty -m "Initialize GitHub Pages"
             git push origin gh-pages
-            git checkout -
+            git checkout "$ORIG"
           fi
 
       - name: Install Helm

--- a/helm/kubeuser/Chart.yaml
+++ b/helm/kubeuser/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
 name: kubeuser
-description: A Helm chart for KubeUser - Kubernetes-native user management operator
 type: application
 version: 0.1.0
 appVersion: "v0.1.0"


### PR DESCRIPTION
## Summary

- Replace `ACTION_PAT` with scoped `GITHUB_TOKEN` — no manual secrets needed
- Fix `snap install yq` which is broken in GitHub-hosted runners (replaced with `mikefarah/yq@v4`)
- Fix GHCR image push failing due to mixed-case repository owner name
- Fix `chart-releaser` failing on first run when `gh-pages` branch doesn't exist
- Add `workflow_dispatch` trigger for manual re-runs without re-pushing a tag

closes #79 

## Changes

### `.github/workflows/release.yml`
- `permissions: {}` deny-all at workflow level with per-job grants (`packages: write`, `contents: write`)
- `concurrency: cancel-in-progress: false` — prevents two releases racing, never kills an in-flight release
- `docker/login-action@v3` + `docker/build-push-action@v5` with Buildx and GHA layer cache
- Lowercase image name via `tr` to satisfy OCI registry requirements
- `persist-credentials: false` on the controller job checkout
- Auto-initialise `gh-pages` orphan branch on first release (no-op on subsequent runs)
- `helm lint` step before chart-releaser to catch bad charts early

### `.github/cr.yaml` (new)
- `release-name-template: "v{{ .Version }}"` — release titled `v0.2.0` instead of `kubeuser-0.2.0`
- `generate-release-notes: true` — GitHub auto-generates commit-based release notes

### `helm/kubeuser/Chart.yaml`
- Removed `description` field — was being used as GitHub Release body, now release body is purely auto-generated commit notes

## Test plan

- [x] Tested end-to-end on a private fork
- [x] Docker image pushed successfully to GHCR
- [x] GitHub Release created with chart tarball as asset
- [x] `gh-pages` branch created and `index.yaml` populated
- [x] `helm repo add` + `helm search repo` returns correct versions