### PR TITLE
fix: reject usernames with 'system:' prefix to prevent CN spoofing

### DIFF
--- a/internal/controller/auth/auth.go
+++ b/internal/controller/auth/auth.go
@@ -26,6 +26,14 @@ const (
 	DefaultTTL = "2160h" // 90 days
 )
 
+// ReservedIdentityPrefix is the prefix Kubernetes reserves for built-in
+// identities (system:masters, system:kube-controller-manager,
+// system:serviceaccount:*, etc.). A User whose metadata.name carries this
+// prefix would mint an x509 certificate whose Subject CN forges a privileged
+// identity, so every layer that can create a User or issue credentials
+// rejects it.
+const ReservedIdentityPrefix = "system:"
+
 // Provider defines the interface for authentication providers
 type Provider interface {
 	// Ensure creates or updates authentication credentials for the user
@@ -119,19 +127,29 @@ func (m *Manager) getProvider(user *authv1alpha1.User) (Provider, error) {
 	}
 }
 
+// ValidateUserIdentity rejects User names that would forge a Kubernetes
+// built-in identity when embedded as the Subject CN of the generated x509
+// certificate. Called from the admission webhook (fast reject at create/update)
+// and from every reconciler entrypoint that mints credentials, so that a User
+// which somehow lands in etcd without passing the webhook (direct etcd write,
+// pre-existing object, misconfigured admission chain) still cannot be issued a
+// certificate.
+//
+// In practice kube-apiserver's RFC 1123 name validation already rejects the
+// ':' character in metadata.name on the normal API path, but that guarantee
+// is not part of our contract with the API server and defense in depth here
+// is cheap.
+func ValidateUserIdentity(user *authv1alpha1.User) error {
+	if strings.HasPrefix(user.Name, ReservedIdentityPrefix) {
+		return fmt.Errorf("metadata.name %q is invalid: names starting with %q are reserved for Kubernetes built-in identities and would forge a privileged certificate Subject CN",
+			user.Name, ReservedIdentityPrefix)
+	}
+	return nil
+}
+
 // ValidateAuthSpec validates the auth specification for the user
 // MANDATORY IDENTITY: Enforces explicit authentication type specification
 func ValidateAuthSpec(user *authv1alpha1.User) error {
-	// SECURITY: Reject usernames with 'system:' prefix to prevent CN spoofing.
-	// Kubernetes reserves the 'system:' prefix for built-in identities (e.g.,
-	// system:kube-controller-manager, system:serviceaccount:...). Allowing user
-	// resources with this prefix would generate X.509 certificates whose Subject
-	// CN matches a privileged identity, enabling privilege escalation via CN
-	// spoofing.
-	if strings.HasPrefix(user.Name, "system:") {
-		return fmt.Errorf("username %q is invalid: the 'system:' prefix is reserved for Kubernetes built-in identities and cannot be used to prevent certificate CN spoofing", user.Name)
-	}
-
 	// MANDATORY IDENTITY ENFORCEMENT: Auth must be non-nil
 	if user.Spec.Auth == nil {
 		return fmt.Errorf("authentication section is mandatory: spec.auth must be specified")

--- a/internal/controller/auth/auth.go
+++ b/internal/controller/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
@@ -121,6 +122,16 @@ func (m *Manager) getProvider(user *authv1alpha1.User) (Provider, error) {
 // ValidateAuthSpec validates the auth specification for the user
 // MANDATORY IDENTITY: Enforces explicit authentication type specification
 func ValidateAuthSpec(user *authv1alpha1.User) error {
+	// SECURITY: Reject usernames with 'system:' prefix to prevent CN spoofing.
+	// Kubernetes reserves the 'system:' prefix for built-in identities (e.g.,
+	// system:kube-controller-manager, system:serviceaccount:...). Allowing user
+	// resources with this prefix would generate X.509 certificates whose Subject
+	// CN matches a privileged identity, enabling privilege escalation via CN
+	// spoofing.
+	if strings.HasPrefix(user.Name, "system:") {
+		return fmt.Errorf("username %q is invalid: the 'system:' prefix is reserved for Kubernetes built-in identities and cannot be used to prevent certificate CN spoofing", user.Name)
+	}
+
 	// MANDATORY IDENTITY ENFORCEMENT: Auth must be non-nil
 	if user.Spec.Auth == nil {
 		return fmt.Errorf("authentication section is mandatory: spec.auth must be specified")

--- a/internal/controller/auth/auth_test.go
+++ b/internal/controller/auth/auth_test.go
@@ -17,6 +17,72 @@ func stringPtr(s string) *string {
 	return &s
 }
 
+func TestValidateUserIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		userName string
+		wantErr  bool
+	}{
+		{
+			name:     "plain username is accepted",
+			userName: "alice",
+			wantErr:  false,
+		},
+		{
+			name:     "dotted/hyphenated RFC 1123 name is accepted",
+			userName: "team-a.svc-01",
+			wantErr:  false,
+		},
+		{
+			name:     "empty name is accepted (other validators cover empty)",
+			userName: "",
+			wantErr:  false,
+		},
+		{
+			name:     "system:masters is rejected (issue #66)",
+			userName: "system:masters",
+			wantErr:  true,
+		},
+		{
+			name:     "system:kube-controller-manager is rejected",
+			userName: "system:kube-controller-manager",
+			wantErr:  true,
+		},
+		{
+			name:     "system:serviceaccount:kube-system:default is rejected",
+			userName: "system:serviceaccount:kube-system:default",
+			wantErr:  true,
+		},
+		{
+			name:     "bare 'system:' prefix is rejected",
+			userName: "system:",
+			wantErr:  true,
+		},
+		{
+			name:     "'system:' substring not at start is accepted",
+			userName: "not-a-system:masters",
+			wantErr:  false,
+		},
+		{
+			name:     "prefix check is case-sensitive (matches Kubernetes)",
+			userName: "System:Masters",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user := &authv1alpha1.User{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.userName},
+			}
+			err := ValidateUserIdentity(user)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUserIdentity(%q) error = %v, wantErr %v", tt.userName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateAuthSpec(t *testing.T) {
 	// Save and restore environment variable
 	originalMinDuration := os.Getenv("KUBEUSER_MIN_DURATION")

--- a/internal/controller/auth/x509.go
+++ b/internal/controller/auth/x509.go
@@ -56,6 +56,12 @@ func (p *X509Provider) Ensure(ctx context.Context, user *authv1alpha1.User) (boo
 		return false, nil, fmt.Errorf("authentication section is mandatory")
 	}
 
+	// Last line of defense before minting a certificate: refuse reserved
+	// identity prefixes. user.Name becomes the Subject CN downstream.
+	if err := ValidateUserIdentity(user); err != nil {
+		return false, nil, fmt.Errorf("invalid user identity: %w", err)
+	}
+
 	logger.Info("Ensuring x509 authentication", "user", user.Name, "autoRenew", helpers.GetAutoRenew(user))
 
 	// Validate auth spec

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -178,6 +178,16 @@ func (r *UserReconciler) reconcileBusinessLogic(ctx context.Context, user *authv
 	logger := logf.FromContext(ctx)
 	needsStatusUpdate := false
 
+	// Reject reserved identity prefixes before any credential work. Defense in
+	// depth: the webhook rejects at admission, but a User that landed in etcd
+	// without passing the webhook must not be issued a certificate.
+	if err := auth.ValidateUserIdentity(user); err != nil {
+		logger.Error(err, "Invalid user identity")
+		user.Status.Phase = helpers.PhaseError
+		user.Status.Message = fmt.Sprintf("Invalid user identity: %v", err)
+		return true, nil, err
+	}
+
 	// Validate auth specification
 	if err := auth.ValidateAuthSpec(user); err != nil {
 		logger.Error(err, "Invalid auth specification")

--- a/internal/webhook/user_webhook.go
+++ b/internal/webhook/user_webhook.go
@@ -98,6 +98,11 @@ func (w *UserWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (a
 	logger := logf.FromContext(ctx).WithName("user-webhook-create")
 	logger.Info("Validating User creation", "user", user.Name)
 
+	// Reject reserved identity prefixes before touching the API server
+	if err := auth.ValidateUserIdentity(user); err != nil {
+		return nil, err
+	}
+
 	// Validate Role references
 	if err := w.validateRoles(ctx, user.Spec.Roles); err != nil {
 		return nil, err
@@ -134,6 +139,13 @@ func (w *UserWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime
 	if newUser.DeletionTimestamp != nil {
 		logger.Info("Skipping validation for User being deleted", "user", newUser.Name)
 		return nil, nil
+	}
+
+	// Reject reserved identity prefixes. metadata.name is immutable, so this
+	// only catches objects that slipped past ValidateCreate (webhook down,
+	// direct etcd write, pre-existing object).
+	if err := auth.ValidateUserIdentity(newUser); err != nil {
+		return nil, err
 	}
 
 	// Validate Role references in the updated spec


### PR DESCRIPTION
## Problem

Kubernetes reserves the  prefix for built-in identities (e.g., , ). If a KubeUser resource is created with a name starting with , the generated X.509 certificate would have a Common Name (CN) matching a privileged built-in identity, allowing an attacker to impersonate system components and escalate privileges.

## Changes

- Add input validation in  to reject any username that begins with  before certificate generation proceeds.
- Added  import to .

## Security Impact

**High** - Without this check, any user with permission to create KubeUser resources could forge certificates for system identities.

Closes #66