### PR TITLE
refactor(api): centralize auth.openkube.io/* string constants in api/v1alpha1

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1alpha1
+
+// GroupName is the API group for all KubeUser resources. Single source of
+// truth — every label, annotation, and finalizer constant in this file
+// derives from it, and groupversion_info.go uses the same value for the
+// CRD GroupVersion. Changing this string is a breaking API change.
+const GroupName = "auth.openkube.io"
+
+// CSRNameAnnotation is the key used on a rotation Shadow Secret to record
+// the name of the in-flight CSR. It lives on metadata.annotations (not in
+// data) because the CSR object itself is cluster-visible — the name is
+// not secret. The writer (createShadowSecretForRotation) and every reader
+// must reference this constant; typing the literal at a call site is the
+// drift pattern that produced the silent rotation desync bug.
+const CSRNameAnnotation = GroupName + "/csr-name"

--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -16,6 +16,16 @@ package v1alpha1
 // CRD GroupVersion. Changing this string is a breaking API change.
 const GroupName = "auth.openkube.io"
 
+// Labels identify operator-managed resources. Treated as public contract:
+// external tooling, dashboards, and kubectl selectors may depend on these
+// values — they cannot be changed without a major-version bump.
+const (
+	UserLabel     = GroupName + "/user"     // value: <username>
+	RotationLabel = GroupName + "/rotation" // value: "true" during a rotation
+	ShadowLabel   = GroupName + "/shadow"   // value: "true" on the temp Secret
+	RenewalLabel  = GroupName + "/renewal"  // value: "true" on the renewal CSR
+)
+
 // CSRNameAnnotation is the key used on a rotation Shadow Secret to record
 // the name of the in-flight CSR. It lives on metadata.annotations (not in
 // data) because the CSR object itself is cluster-visible — the name is
@@ -23,3 +33,8 @@ const GroupName = "auth.openkube.io"
 // must reference this constant; typing the literal at a call site is the
 // drift pattern that produced the silent rotation desync bug.
 const CSRNameAnnotation = GroupName + "/csr-name"
+
+// UserFinalizer holds User deletion until controller cleanup completes.
+// Stored on User.Finalizers; removed only after CleanupUserResources
+// successfully purges every managed resource.
+const UserFinalizer = GroupName + "/finalizer"

--- a/internal/controller/certs/certs.go
+++ b/internal/controller/certs/certs.go
@@ -265,7 +265,7 @@ func getOrCreateCSR(ctx context.Context, r client.Client, csrName, username stri
 	newCSR := certv1.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   csrName,
-			Labels: map[string]string{"auth.openkube.io/user": username},
+			Labels: map[string]string{authv1alpha1.UserLabel: username},
 		},
 		Spec: certv1.CertificateSigningRequestSpec{
 			Request:           csrPEM,

--- a/internal/controller/cleanup/finalizers.go
+++ b/internal/controller/cleanup/finalizers.go
@@ -21,13 +21,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	UserFinalizer = "auth.openkube.io/finalizer"
-
-	// userLabel selects all operator-managed resources for a given User.
-	userLabel = "auth.openkube.io/user"
-)
-
 // CleanupUserResources deletes resources owned by the user. Best-effort:
 // per-resource failures are logged but never block finalizer removal.
 func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alpha1.User) {
@@ -39,7 +32,7 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 	logger := logf.FromContext(ctx).WithName("cleanup")
 	username := user.Name
 	userNamespace := helpers.GetKubeUserNamespace()
-	selector := client.MatchingLabels{userLabel: username}
+	selector := client.MatchingLabels{authv1alpha1.UserLabel: username}
 
 	// Delete steady-state secrets by name. They aren't labelled at creation,
 	// so the label-selector passes below won't catch them.

--- a/internal/controller/rbac/bindings.go
+++ b/internal/controller/rbac/bindings.go
@@ -27,7 +27,7 @@ func ReconcileRoleBindings(ctx context.Context, r client.Client, user *authv1alp
 
 	// Get all existing RoleBindings for this user
 	var existingRBs rbacv1.RoleBindingList
-	if err := r.List(ctx, &existingRBs, client.MatchingLabels{"auth.openkube.io/user": username}); err != nil {
+	if err := r.List(ctx, &existingRBs, client.MatchingLabels{authv1alpha1.UserLabel: username}); err != nil {
 		return fmt.Errorf("failed to list existing RoleBindings: %w", err)
 	}
 
@@ -92,9 +92,9 @@ func ReconcileRoleBindings(ctx context.Context, r client.Client, user *authv1alp
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      rbName,
 				Namespace: roleSpec.Namespace,
-				Labels:    map[string]string{"auth.openkube.io/user": username},
+				Labels:    map[string]string{authv1alpha1.UserLabel: username},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: "auth.openkube.io/v1alpha1",
+					APIVersion: authv1alpha1.GroupVersion.String(),
 					Kind:       "User",
 					Name:       user.Name,
 					UID:        user.UID,
@@ -150,7 +150,7 @@ func ReconcileClusterRoleBindings(ctx context.Context, r client.Client, user *au
 
 	// Get all existing ClusterRoleBindings for this user
 	var existingCRBs rbacv1.ClusterRoleBindingList
-	if err := r.List(ctx, &existingCRBs, client.MatchingLabels{"auth.openkube.io/user": username}); err != nil {
+	if err := r.List(ctx, &existingCRBs, client.MatchingLabels{authv1alpha1.UserLabel: username}); err != nil {
 		return fmt.Errorf("failed to list existing ClusterRoleBindings: %w", err)
 	}
 
@@ -181,9 +181,9 @@ func ReconcileClusterRoleBindings(ctx context.Context, r client.Client, user *au
 		desiredCRB := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   crbName,
-				Labels: map[string]string{"auth.openkube.io/user": username},
+				Labels: map[string]string{authv1alpha1.UserLabel: username},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: "auth.openkube.io/v1alpha1",
+					APIVersion: authv1alpha1.GroupVersion.String(),
 					Kind:       "User",
 					Name:       user.Name,
 					UID:        user.UID,

--- a/internal/controller/renewal/rotation.go
+++ b/internal/controller/renewal/rotation.go
@@ -370,9 +370,9 @@ func (rm *RotationManager) createShadowSecretForRotation(ctx context.Context, us
 			Name:      shadowSecretName,
 			Namespace: userNamespace,
 			Labels: map[string]string{
-				"auth.openkube.io/user":     username,
-				"auth.openkube.io/rotation": "true",
-				"auth.openkube.io/shadow":   "true",
+				authv1alpha1.UserLabel:     username,
+				authv1alpha1.RotationLabel: "true",
+				authv1alpha1.ShadowLabel:   "true",
 			},
 			Annotations: map[string]string{
 				authv1alpha1.CSRNameAnnotation: csrName,
@@ -445,9 +445,9 @@ func (rm *RotationManager) ensureCSRExists(ctx context.Context, user *authv1alph
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrName,
 			Labels: map[string]string{
-				"auth.openkube.io/user":     username,
-				"auth.openkube.io/renewal":  "true",
-				"auth.openkube.io/rotation": "true",
+				authv1alpha1.UserLabel:     username,
+				authv1alpha1.RenewalLabel:  "true",
+				authv1alpha1.RotationLabel: "true",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -899,11 +899,11 @@ func (rm *RotationManager) validateCSRForApproval(csr *certv1.CertificateSigning
 		return fmt.Errorf("missing required labels")
 	}
 
-	if csr.Labels["auth.openkube.io/renewal"] != "true" {
+	if csr.Labels[authv1alpha1.RenewalLabel] != "true" {
 		return fmt.Errorf("missing or invalid renewal label")
 	}
 
-	if csr.Labels["auth.openkube.io/rotation"] != "true" {
+	if csr.Labels[authv1alpha1.RotationLabel] != "true" {
 		return fmt.Errorf("missing or invalid rotation label")
 	}
 
@@ -919,7 +919,7 @@ func (rm *RotationManager) validateCSRForApproval(csr *certv1.CertificateSigning
 	}
 
 	// Validate common name matches expected user
-	expectedUsername := csr.Labels["auth.openkube.io/user"]
+	expectedUsername := csr.Labels[authv1alpha1.UserLabel]
 	if csrReq.Subject.CommonName != expectedUsername {
 		return fmt.Errorf("CSR common name %s doesn't match expected user %s", csrReq.Subject.CommonName, expectedUsername)
 	}

--- a/internal/controller/renewal/rotation.go
+++ b/internal/controller/renewal/rotation.go
@@ -157,7 +157,7 @@ func (rm *RotationManager) continueRotationFromShadow(ctx context.Context, user 
 	username := user.Name
 
 	// Extract rotation metadata from Shadow Secret
-	csrName, exists := shadowSecret.Annotations["auth.openkube.io/csr-name"]
+	csrName, exists := shadowSecret.Annotations[authv1alpha1.CSRNameAnnotation]
 	if !exists {
 		logger.Error(nil, "Shadow Secret missing CSR name annotation - non-recoverable, cleaning up", "shadowSecret", shadowSecret.Name)
 		rm.eventRecorder.Event(user, "Warning", "RotationCorrupted", "Shadow Secret missing CSR annotation, resetting rotation state")
@@ -375,7 +375,7 @@ func (rm *RotationManager) createShadowSecretForRotation(ctx context.Context, us
 				"auth.openkube.io/shadow":   "true",
 			},
 			Annotations: map[string]string{
-				"auth.openkube.io/csr-name": csrName,
+				authv1alpha1.CSRNameAnnotation: csrName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -835,7 +835,7 @@ func (rm *RotationManager) IsRotationInProgress(ctx context.Context, username st
 		return false, "", nil
 	}
 
-	csrName := string(shadowSecret.Data["csr.name"])
+	csrName := shadowSecret.Annotations[authv1alpha1.CSRNameAnnotation]
 	return true, csrName, nil
 }
 

--- a/internal/controller/renewal/rotation_test.go
+++ b/internal/controller/renewal/rotation_test.go
@@ -84,10 +84,12 @@ func TestRotationManager_IsRotationInProgress(t *testing.T) {
 						"auth.openkube.io/rotation": "true",
 						"auth.openkube.io/shadow":   "true",
 					},
+					Annotations: map[string]string{
+						authv1alpha1.CSRNameAnnotation: "bob-renewal-12345678",
+					},
 				},
 				Data: map[string][]byte{
-					"key.pem":  []byte("fake-key"),
-					"csr.name": []byte("bob-renewal-12345678"),
+					"key.pem": []byte("fake-key"),
 				},
 			},
 			wantInProgress: true,
@@ -351,5 +353,50 @@ func TestRotationManager_validateCSRForApproval(t *testing.T) {
 				t.Errorf("validateCSRForApproval() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestRotationManager_IsRotationInProgress_RoundTripsCSRName is the regression
+// guard for the silent CSR-name drift bug. createShadowSecretForRotation writes
+// the CSR name to annotations; IsRotationInProgress must read from the same
+// place. The test deliberately uses both production code paths — any future
+// asymmetry in field or key fails the assertion loudly.
+func TestRotationManager_IsRotationInProgress_RoundTripsCSRName(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	rm := NewRotationManager(cli, nil, "kubernetes.io/kube-apiserver-client", nil)
+
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alice",
+			UID:  "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	// Production WRITE path.
+	if err := rm.createShadowSecretForRotation(context.Background(), user); err != nil {
+		t.Fatalf("createShadowSecretForRotation: %v", err)
+	}
+
+	// Production READ path.
+	inProgress, csrName, err := rm.IsRotationInProgress(context.Background(), user.Name)
+	if err != nil {
+		t.Fatalf("IsRotationInProgress: %v", err)
+	}
+	if !inProgress {
+		t.Fatalf("expected rotation in progress = true, got false")
+	}
+	if csrName == "" {
+		t.Fatalf("CSR name came back empty — writer and reader are using different field or key")
+	}
+	// generateUniqueCSRName is deterministic for (alice, 12345678-...).
+	if want := "alice-renewal-12345678"; csrName != want {
+		t.Errorf("CSR name round trip = %q, want %q", csrName, want)
 	}
 }

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -243,7 +243,7 @@ func (r *UserReconciler) handleDeletion(ctx context.Context, user *authv1alpha1.
 	logger := logf.FromContext(ctx)
 	logger.Info("User is being deleted, starting cleanup")
 
-	if helpers.ContainsString(user.Finalizers, cleanup.UserFinalizer) {
+	if helpers.ContainsString(user.Finalizers, authv1alpha1.UserFinalizer) {
 		// Step 1: Clean up all user resources BEFORE removing finalizer
 		// This ensures cleanup is complete even if finalizer removal fails
 		logger.Info("Cleaning up user resources")
@@ -251,7 +251,7 @@ func (r *UserReconciler) handleDeletion(ctx context.Context, user *authv1alpha1.
 
 		// Step 2: Remove finalizer as the absolute last step
 		logger.Info("Removing finalizer")
-		user.Finalizers = helpers.RemoveString(user.Finalizers, cleanup.UserFinalizer)
+		user.Finalizers = helpers.RemoveString(user.Finalizers, authv1alpha1.UserFinalizer)
 		if err := r.Update(ctx, user); err != nil {
 			// Handle harmless race conditions that occur during concurrent deletion reconciliations
 			// These are expected and should not trigger error alerts in observability systems
@@ -293,9 +293,9 @@ func (r *UserReconciler) handleDeletion(ctx context.Context, user *authv1alpha1.
 func (r *UserReconciler) ensureFinalizer(ctx context.Context, user *authv1alpha1.User) error {
 	logger := logf.FromContext(ctx)
 
-	if !helpers.ContainsString(user.Finalizers, cleanup.UserFinalizer) {
-		logger.Info("Adding finalizer", "finalizer", cleanup.UserFinalizer)
-		user.Finalizers = append(user.Finalizers, cleanup.UserFinalizer)
+	if !helpers.ContainsString(user.Finalizers, authv1alpha1.UserFinalizer) {
+		logger.Info("Adding finalizer", "finalizer", authv1alpha1.UserFinalizer)
+		user.Finalizers = append(user.Finalizers, authv1alpha1.UserFinalizer)
 		if err := r.Update(ctx, user); err != nil {
 			logger.Error(err, "Failed to add finalizer")
 			return err


### PR DESCRIPTION

## Summary

Follow-up to #55 (PR #83). That fix introduced `api/v1alpha1.CSRNameAnnotation`
to kill a single drift-prone literal. This PR finishes the job: every
`auth.openkube.io/...` identifier string in production code now references a
constant in `api/v1alpha1`, so a writer and a reader can no longer disagree
about a key the way they did in #55.

Two patterns are addressed:

1. **Label / annotation / finalizer keys** — now sourced from new constants in
   `api/v1alpha1/labels.go` (`UserLabel`, `RotationLabel`, `ShadowLabel`,
   `RenewalLabel`, `UserFinalizer`).
2. **`OwnerReferences.APIVersion` strings** — were hand-typed as
   `"auth.openkube.io/v1alpha1"`; now derived from the existing
   `v1alpha1.GroupVersion.String()`, so an API version bump can't leave stale
   apiVersions behind.

This is a pure, behavior-preserving refactor. **No test files were modified** —
the unchanged test suite passing is the proof that behavior is identical.

> **Note for reviewers:** this PR is stacked on `fix/issue-55-csr-name-annotation`
> (PR #83). Review/merge #83 first. Once it merges, this PR retargets to `main`
> automatically and the diff stays limited to the 5 refactor commits below.

Closes #84 

## Changes

Five commits, one concern each, every commit compiles cleanly (bisect-safe):

- **`feat(api): expand labels.go`** — adds `UserLabel`, `RotationLabel`,
  `ShadowLabel`, `RenewalLabel`, `UserFinalizer` (all derived from `GroupName`),
  each with a doc-comment noting the public-contract stability guarantee.
- **`refactor(cleanup)`** — deletes the locally-declared `UserFinalizer`
  (exported) and `userLabel` (private) constants from
  `cleanup/finalizers.go`; the package and its 5 callers in
  `user_controller.go` now reference `v1alpha1.UserFinalizer` /
  `v1alpha1.UserLabel`. (Atomic two-file commit — the deletion and its callers
  must move together.)
- **`refactor(renewal)`** — replaces 9 inline label literals in `rotation.go`
  (shadow-secret labels, renewal-CSR labels, and the CSR validation readers)
  with the `v1alpha1` constants.
- **`refactor(rbac)`** — replaces 4 `UserLabel` literals in `bindings.go`, and
  swaps the 2 hand-typed `"auth.openkube.io/v1alpha1"` apiVersion strings for
  `v1alpha1.GroupVersion.String()`.
- **`refactor(certs)`** — replaces the 1 `UserLabel` literal in the CSR
  creation path.

Diff: 6 files, +37 / −29. No behavior change. No CRD/RBAC/wire-format change.

## Verification

- [x] `go build ./...` — clean.
- [x] `gofmt -l cmd internal api` — empty (no formatting drift).
- [x] `go vet ./...` — clean.
- [x] `go test ./...` — **all packages pass, with zero test-file changes.**
      This is the core correctness signal: a mechanical refactor that preserves
      behavior must not require touching a single test.
- [x] **Acceptance criterion — no inline label/annotation/finalizer literals
      remain in production code:**
      `grep -rn '"auth\.openkube\.io/' --include='*.go' --exclude='*_test.go' internal/ cmd/`
      → **0 results**.
- [x] **Acceptance criterion — no inline apiVersion literals remain:**
      `grep -rn '"auth\.openkube\.io/v1alpha1"' --include='*.go' --exclude='*_test.go' internal/ cmd/`
      → **0 results**.
- [x] **No test files modified:** `git diff --stat <base> -- '*_test.go'`
      is empty.

## Risk

Very low.

- Pure refactor; no logic, signatures, CRD, RBAC, or serialized values change.
- The constants resolve to byte-identical strings (`GroupName + "/user"` ==
  `"auth.openkube.io/user"`), so emitted labels/annotations/finalizers and
  selector queries are unchanged on the wire. Existing objects in a live
  cluster continue to match.
- `OwnerReferences.APIVersion` via `GroupVersion.String()` produces exactly
  `"auth.openkube.io/v1alpha1"` — identical to the previous literal.
- No test changes by design — behavior preservation is demonstrated by the
  unchanged suite passing.


