### PR TITLE
feat(release): signed release pipeline (cosign + PGP)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
         env:
           HELM_GPG_PASSPHRASE: ${{ secrets.HELM_GPG_PASSPHRASE }}
           KEY_ID: ${{ steps.gpg.outputs.keyid }}
+          # Helm's --key flag matches a substring of the GPG UID, not the key
+          # id, so chart-releaser's CR_KEY must be the identity name/email.
+          KEY_NAME: ${{ steps.gpg.outputs.name }}
         run: |
           KEYRING="$RUNNER_TEMP/secring.gpg"
           PASSPHRASE_FILE="$RUNNER_TEMP/gpg-passphrase"
@@ -158,7 +161,7 @@ jobs:
 
           {
             echo "CR_SIGN=true"
-            echo "CR_KEY=$KEY_ID"
+            echo "CR_KEY=$KEY_NAME"
             echo "CR_KEYRING=$KEYRING"
             echo "CR_PASSPHRASE_FILE=$PASSPHRASE_FILE"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,11 @@ jobs:
           gpg --armor --export "$KEY_ID" > "$WORKDIR/release-key.asc"
 
           cd "$WORKDIR"
-          if git diff --quiet -- release-key.asc; then
+          # Use porcelain (not `git diff`) so the first-run untracked case
+          # is also detected — `git diff` only inspects tracked files and
+          # would otherwise report "no change" when the key has never been
+          # published.
+          if [[ -z "$(git status --porcelain -- release-key.asc)" ]]; then
             echo "Public key unchanged; nothing to publish."
             exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,15 @@ env:
 
 jobs:
   # --------------------------------------------------
-  # Job 1: Build and push controller image to GHCR
+  # Job 1: Build, push, and cosign-sign the controller image
   # --------------------------------------------------
   release-controller:
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      packages: write   # push to GHCR with built-in GITHUB_TOKEN
+      packages: write    # push to GHCR with built-in GITHUB_TOKEN
+      id-token: write    # request OIDC token for cosign keyless signing
 
     steps:
       - name: Checkout code
@@ -55,6 +56,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push controller image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -64,8 +66,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.4.1
+
+      # Sign by digest — never by tag — so the signature is bound to the exact
+      # content that was just pushed and cannot be invalidated by a later retag.
+      - name: Sign controller image (keyless OIDC)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "$IMAGE_REF"
+
   # --------------------------------------------------
-  # Job 2: Package and release Helm chart
+  # Job 2: Package, PGP-sign, and release the Helm chart
   # Uses chart-releaser-action — stores each chart version
   # as a GitHub Release asset, preserving full history.
   # --------------------------------------------------
@@ -117,6 +131,38 @@ jobs:
       - name: Lint chart
         run: helm lint helm/kubeuser
 
+      # Import the signing key into the runner's gpg agent and derive a legacy
+      # secring file (Helm's --keyring expects the pre-2.1 secring format).
+      - name: Import GPG signing key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.HELM_GPG_KEY }}
+          passphrase: ${{ secrets.HELM_GPG_PASSPHRASE }}
+
+      - name: Prepare keyring and passphrase for chart-releaser
+        env:
+          HELM_GPG_PASSPHRASE: ${{ secrets.HELM_GPG_PASSPHRASE }}
+          KEY_ID: ${{ steps.gpg.outputs.keyid }}
+        run: |
+          KEYRING="$RUNNER_TEMP/secring.gpg"
+          PASSPHRASE_FILE="$RUNNER_TEMP/gpg-passphrase"
+
+          gpg --batch --yes --pinentry-mode loopback \
+              --passphrase "$HELM_GPG_PASSPHRASE" \
+              --export-secret-keys "$KEY_ID" > "$KEYRING"
+          chmod 600 "$KEYRING"
+
+          printf '%s' "$HELM_GPG_PASSPHRASE" > "$PASSPHRASE_FILE"
+          chmod 600 "$PASSPHRASE_FILE"
+
+          {
+            echo "CR_SIGN=true"
+            echo "CR_KEY=$KEY_ID"
+            echo "CR_KEYRING=$KEYRING"
+            echo "CR_PASSPHRASE_FILE=$PASSPHRASE_FILE"
+          } >> "$GITHUB_ENV"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:
@@ -125,3 +171,30 @@ jobs:
           skip_existing: true   # safe to re-run — skips already released versions
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # CR_SIGN / CR_KEY / CR_KEYRING / CR_PASSPHRASE_FILE come from the
+          # previous step; cr (via viper) reads them with the CR_ prefix.
+
+      # Publish the ASCII-armored public key alongside the index so users have
+      # a stable URL for `gpg --import` before running `helm pull --verify`.
+      - name: Publish public key to gh-pages
+        env:
+          KEY_ID: ${{ steps.gpg.outputs.keyid }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          WORKDIR="$RUNNER_TEMP/gh-pages-key"
+          git clone --depth 1 --branch gh-pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
+            "$WORKDIR"
+
+          gpg --armor --export "$KEY_ID" > "$WORKDIR/release-key.asc"
+
+          cd "$WORKDIR"
+          if git diff --quiet -- release-key.asc; then
+            echo "Public key unchanged; nothing to publish."
+            exit 0
+          fi
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add release-key.asc
+          git commit -m "chore(gh-pages): publish release signing key ($KEY_ID)"
+          git push origin gh-pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,24 @@
-# Build the manager binary
-FROM golang:1.24 AS builder
+# Build the manager binary.
+# Pin the builder to the runner's native arch ($BUILDPLATFORM) and let Go
+# cross-compile to $TARGETARCH — avoids QEMU emulation on multi-arch builds.
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the go source
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
 
-# Build
-# the GOARCH has no default value to allow the binary to be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -trimpath -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/README.md
+++ b/README.md
@@ -349,6 +349,37 @@ kubectl auth can-i create certificatesigningrequests \
 
 ---
 
+## Verifying Releases
+
+Every release is signed: the controller image with **cosign keyless** (Sigstore,
+Fulcio, Rekor) and the Helm chart with a **PGP** key whose public half is
+published on the chart repo.
+
+### Verify the controller image
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github.com/openkube-hub/KubeUser/\.github/workflows/release\.yml@refs/tags/v.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/openkube-hub/kubeuser-controller:<version>
+```
+
+### Verify the Helm chart
+
+```bash
+curl -fsSL https://openkube-hub.github.io/KubeUser/release-key.asc \
+  | gpg --dearmor > /tmp/kubeuser-pubring.gpg
+helm pull kubeuser/kubeuser \
+  --verify --keyring /tmp/kubeuser-pubring.gpg \
+  --version <version>
+```
+
+See [docs/release-verification.md](docs/release-verification.md) for the full
+procedure, the values to substitute when verifying against a fork, and the
+release-side runbook for rotating the signing key.
+
+---
+
 ## Documentation
 
 - [Certificate Management](docs/certificate-management.md)
@@ -356,6 +387,7 @@ kubectl auth can-i create certificatesigningrequests \
 - [Webhook Validation](docs/webhook-validation.md)
 - [Metrics Reference](docs/metrics.md)
 - [Accessing Metrics](docs/accessing-metrics.md)
+- [Release Verification](docs/release-verification.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@ KubeUser solves this by managing Kubernetes users through declarative custom res
 
 #### 🚧 Planned
 
-- [ ] **x509 Group Membership** — `O=` field support for RBAC group bindings
+- [ ] **x509 Group Membership** — `O=` field support for RBAC group bindings (not certain)
 - [ ] **Certificate Revocation Notification** — admission warning and event on User deletion
 - [ ] **Audit Log** — immutable record of every certificate issuance and rotation event
 - [ ] **Short-Lived Certificates (< 24h)** — sub-24h TTL for ephemeral, zero-trust access
 - [ ] **ECDSA Key Support** — configurable key algorithm via `spec.auth.keyAlgorithm`
 - [ ] **OpenTelemetry Tracing** — end-to-end traces across reconcile and rotation paths
 - [ ] **Predefined Role Templates** — curated library for common access patterns
+- [ ] **Web UI** — browser-based dashboard for managing users
 
 ---
 
@@ -309,77 +310,6 @@ For Prometheus metrics, Grafana dashboards, and alerting rules see [docs/metrics
 
 ---
 
-## Troubleshooting
-
-### Controller Pod Not Starting
-
-```bash
-kubectl get pods -n kubeuser
-kubectl logs -n kubeuser deployment/kubeuser-controller-manager
-kubectl get events -n kubeuser --sort-by=.lastTimestamp
-```
-
-**Common causes:** missing cert-manager, webhook certificate not ready, image pull issues.
-
-### Webhook Certificate Issues
-
-```bash
-kubectl get certificates -n kubeuser
-kubectl describe certificate kubeuser-webhook-cert -n kubeuser
-kubectl logs -n cert-manager deployment/cert-manager
-```
-
-### User Creation Fails
-
-```bash
-kubectl describe user <username>
-kubectl logs -n kubeuser deployment/kubeuser-controller-manager | grep -i error
-```
-
-**Common causes:** referenced Role/ClusterRole does not exist, target namespace does not exist, webhook validation failure.
-
-### Certificate Generation Issues
-
-```bash
-kubectl get csr -l auth.openkube.io/user=<username>
-kubectl describe csr <csr-name>
-kubectl auth can-i create certificatesigningrequests \
-  --as=system:serviceaccount:kubeuser:kubeuser-controller-manager
-```
-
----
-
-## Verifying Releases
-
-Every release is signed: the controller image with **cosign keyless** (Sigstore,
-Fulcio, Rekor) and the Helm chart with a **PGP** key whose public half is
-published on the chart repo.
-
-### Verify the controller image
-
-```bash
-cosign verify \
-  --certificate-identity-regexp "^https://github.com/openkube-hub/KubeUser/\.github/workflows/release\.yml@refs/tags/v.*$" \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/openkube-hub/kubeuser-controller:<version>
-```
-
-### Verify the Helm chart
-
-```bash
-curl -fsSL https://openkube-hub.github.io/KubeUser/release-key.asc \
-  | gpg --dearmor > /tmp/kubeuser-pubring.gpg
-helm pull kubeuser/kubeuser \
-  --verify --keyring /tmp/kubeuser-pubring.gpg \
-  --version <version>
-```
-
-See [docs/release-verification.md](docs/release-verification.md) for the full
-procedure, the values to substitute when verifying against a fork, and the
-release-side runbook for rotating the signing key.
-
----
-
 ## Documentation
 
 - [Certificate Management](docs/certificate-management.md)
@@ -388,6 +318,7 @@ release-side runbook for rotating the signing key.
 - [Metrics Reference](docs/metrics.md)
 - [Accessing Metrics](docs/accessing-metrics.md)
 - [Release Verification](docs/release-verification.md)
+- [Troubleshooting](docs/troubleshooting.md)
 
 ---
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,173 @@
+# Release Verification
+
+Every KubeUser release ships two signed artifacts: the controller container
+image (signed with **cosign keyless** via GitHub Actions OIDC) and the Helm
+chart tarball (signed with **PGP** using `helm package --sign`, surfaced as a
+`.prov` file alongside the chart on the chart repository).
+
+This page is for two audiences:
+
+1. **Users** who want to verify a release before installing it.
+2. **Release engineers / fork owners** who need to bootstrap signing in a new
+   repository.
+
+---
+
+## For users
+
+### Verify the controller image
+
+Cosign keyless signing means there is no long-lived public key — the signature
+binds the image digest to the GitHub Actions workflow identity that produced
+it. Verification checks the signing certificate's identity (the workflow URL)
+and OIDC issuer (GitHub's token endpoint).
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github.com/openkube-hub/KubeUser/\.github/workflows/release\.yml@refs/tags/v.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/openkube-hub/kubeuser-controller:<version>
+```
+
+A successful verification prints the certificate subject and the Rekor
+transparency log entry the signature was recorded in.
+
+### Verify the Helm chart
+
+```bash
+# 1. Fetch the public signing key into a legacy-format keyring file.
+#    Helm's --verify reads a binary keyring (gpg2 stores keys in keybox
+#    format by default, which helm cannot read), so we export explicitly.
+curl -fsSL https://openkube-hub.github.io/KubeUser/release-key.asc \
+  | gpg --dearmor > /tmp/kubeuser-pubring.gpg
+
+# 2. Add the chart repo and pull-with-verify against that keyring.
+helm repo add kubeuser https://openkube-hub.github.io/KubeUser
+helm repo update
+helm pull kubeuser/kubeuser \
+  --verify --keyring /tmp/kubeuser-pubring.gpg \
+  --version <version>
+```
+
+`helm pull --verify` downloads both `kubeuser-<version>.tgz` and the
+provenance file `kubeuser-<version>.tgz.prov`, then validates the PGP
+signature in the provenance file against the keyring.
+
+Artifact Hub renders the **Signed** badge automatically based on the
+`artifacthub.io/signKey` annotation in `Chart.yaml`.
+
+### Verifying against a fork
+
+Forks publish under their own GitHub organisation, so substitute the owner
+name in both the cosign identity regex and the public key URL. For
+`MuhanedYahya/KubeUser`:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github.com/MuhanedYahya/KubeUser/\.github/workflows/release\.yml@refs/tags/v.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/muhanedyahya/kubeuser-controller:<version>
+
+curl -fsSL https://muhanedyahya.github.io/KubeUser/release-key.asc \
+  | gpg --dearmor > /tmp/kubeuser-pubring.gpg
+helm repo add kubeuser-fork https://muhanedyahya.github.io/KubeUser
+helm repo update
+helm pull kubeuser-fork/kubeuser \
+  --verify --keyring /tmp/kubeuser-pubring.gpg \
+  --version <version>
+```
+
+---
+
+## For release engineers (bootstrap)
+
+These steps are needed once per repository to enable signed releases. After
+that the release workflow handles signing on every tag push.
+
+### 1. Cosign keyless — no setup required
+
+The image signing job uses GitHub Actions OIDC. The only repository setting
+needed is the `id-token: write` permission on the job (already present in
+`.github/workflows/release.yml`).
+
+### 2. Generate a PGP signing key
+
+```bash
+gpg --full-generate-key
+# Choose: RSA and RSA, 4096 bits, no expiration (or set one and rotate),
+# real name "KubeUser Release Signing Key", email release@<your-domain>,
+# strong passphrase.
+
+# Capture the fingerprint and key ID.
+gpg --list-secret-keys --keyid-format=long
+```
+
+### 3. Export the private key and add repo secrets
+
+```bash
+gpg --armor --export-secret-keys <key-id> > kubeuser-signing.key
+```
+
+In GitHub → repo Settings → Secrets and variables → Actions, add:
+
+| Secret name           | Value                                                |
+| --------------------- | ---------------------------------------------------- |
+| `HELM_GPG_KEY`        | Contents of `kubeuser-signing.key`                   |
+| `HELM_GPG_PASSPHRASE` | The passphrase you set when generating the key       |
+
+Delete the `kubeuser-signing.key` file from disk afterwards. The private key
+should only exist in the secret manager and in your offline backup.
+
+### 4. Update the `artifacthub.io/signKey` annotation
+
+Edit `helm/kubeuser/Chart.yaml` so the `fingerprint` matches the key you
+generated and the `url` points to where the public key will be reachable. For
+forks the workflow publishes it automatically at
+`https://<owner>.github.io/<repo>/release-key.asc` on each release.
+
+```yaml
+annotations:
+  artifacthub.io/signKey: |
+    fingerprint: ABCDEF0123456789ABCDEF0123456789ABCDEF01
+    url: https://muhanedyahya.github.io/KubeUser/release-key.asc
+```
+
+### 5. (Optional) Pre-publish the public key
+
+The release workflow publishes the public key to `gh-pages` on the first
+release, but you can publish it manually before tagging so Artifact Hub can
+fetch it immediately:
+
+```bash
+gpg --armor --export <key-id> > release-key.asc
+git checkout gh-pages
+git add release-key.asc
+git commit -m "Publish release signing key"
+git push origin gh-pages
+git checkout -
+```
+
+### 6. Tag a release and verify end-to-end
+
+```bash
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+Once both jobs finish, run the verification commands from the *For users*
+section above against the freshly published artifacts.
+
+### Rotating the signing key
+
+1. Generate a new PGP key (step 2).
+2. Update `HELM_GPG_KEY` and `HELM_GPG_PASSPHRASE` secrets (step 3).
+3. Update the `artifacthub.io/signKey` annotation with the new fingerprint
+   (step 4).
+4. Tag the next release. The workflow will publish the new public key to
+   `release-key.asc`, overwriting the previous one. Old chart versions remain
+   verifiable as long as users keep the old public key imported, so consider
+   keeping `release-key-<old-fingerprint>.asc` alongside the new key during a
+   transition window.
+
+The cosign keyless signature does not require rotation — each release is bound
+to the workflow identity at the time it ran, and Rekor preserves the
+transparency log entry indefinitely.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting
+
+Common diagnostic commands for the most frequent failure modes when running
+KubeUser. Run these against the namespace where the controller is installed
+(`kubeuser` in the examples below — adjust if you used a different release
+namespace).
+
+## Controller Pod Not Starting
+
+```bash
+kubectl get pods -n kubeuser
+kubectl logs -n kubeuser deployment/kubeuser-controller-manager
+kubectl get events -n kubeuser --sort-by=.lastTimestamp
+```
+
+**Common causes:** missing cert-manager, webhook certificate not ready, image pull issues.
+
+## Webhook Certificate Issues
+
+```bash
+kubectl get certificates -n kubeuser
+kubectl describe certificate kubeuser-webhook-cert -n kubeuser
+kubectl logs -n cert-manager deployment/cert-manager
+```
+
+## User Creation Fails
+
+```bash
+kubectl describe user <username>
+kubectl logs -n kubeuser deployment/kubeuser-controller-manager | grep -i error
+```
+
+**Common causes:** referenced Role/ClusterRole does not exist, target namespace does not exist, webhook validation failure.
+
+## Certificate Generation Issues
+
+```bash
+kubectl get csr -l auth.openkube.io/user=<username>
+kubectl describe csr <csr-name>
+kubectl auth can-i create certificatesigningrequests \
+  --as=system:serviceaccount:kubeuser:kubeuser-controller-manager
+```

--- a/helm/kubeuser/Chart.yaml
+++ b/helm/kubeuser/Chart.yaml
@@ -18,3 +18,6 @@ maintainers:
     url: https://github.com/openkube-hub/KubeUser
 annotations:
   category: Infrastructure
+  artifacthub.io/signKey: |
+    fingerprint: 1C5268D1FA0BEB4C96866096BDDF0BB1E1075A77
+    url: https://muhanedyahya.github.io/KubeUser/release-key.asc

--- a/helm/kubeuser/Chart.yaml
+++ b/helm/kubeuser/Chart.yaml
@@ -19,5 +19,5 @@ maintainers:
 annotations:
   category: Infrastructure
   artifacthub.io/signKey: |
-    fingerprint: 1C5268D1FA0BEB4C96866096BDDF0BB1E1075A77
-    url: https://muhanedyahya.github.io/KubeUser/release-key.asc
+    fingerprint: 280EF6E0A697EF70F327B63B28346DDB12B92C97
+    url: https://openkube-hub.github.io/KubeUser/release-key.asc


### PR DESCRIPTION
Closes #81.

## Summary

Implements signed release artifacts as described in #81:

- **Controller image** signed with **cosign keyless** via GitHub Actions OIDC. Signature binds the image digest to the workflow identity (`refs/tags/v*`) and is recorded in Rekor — verifiable with no long-lived public key.
- **Helm chart** signed with **PGP** via `chart-releaser` (`.prov` files published alongside the tarball on `gh-pages`).
- **Public key + fingerprint** published to `gh-pages` (`/release-key.asc`) on first release; `Chart.yaml` carries the matching `artifacthub.io/signKey` annotation so Artifact Hub displays the **Signed** badge.
- **Verification commands** documented in `README.md` and `docs/release-verification.md` for both user and release-engineer audiences.

End-to-end verified on a fork — both `cosign verify` and `helm pull --verify` pass cleanly against a tagged release.

## Commits in this PR

| | |
|---|---|
| `feat(release): sign controller image with cosign and chart with PGP` | Wires cosign + chart-releaser + PGP key import into `release.yml`. |
| `fix(release): use PAT for GHCR push to unblock new package creation` | `GHCR_TOKEN` PAT fallback for fresh package namespaces — the default `GITHUB_TOKEN` can't create a brand-new GHCR package on first push. |
| `perf(build): cross-compile multi-arch image to avoid QEMU` | Pins builder stage to `\$BUILDPLATFORM` and lets Go cross-compile to `\$TARGETARCH`. Drops release build time from ~17 min to ~5 min by eliminating QEMU emulation of arm64. Also adds BuildKit cache mounts and `-trimpath` for reproducibility. |
| `fix(release): pass GPG UID (not key id) to chart-releaser` | Helm's `--key` flag matches a substring of the GPG identity name, not the hex key id. Passing the id produced \"private key not found\" even though the secret key was present in the keyring. |
| `fix(release): publish gpg key on first run` | `git diff --quiet` only inspects tracked files, so the untracked first-write case was treated as \"no change\" and the public key was never committed to `gh-pages`. Use `git status --porcelain` so new files are also caught. |
| `chore(release): rotate signKey annotation to production fingerprint` | Updates `Chart.yaml` annotation to the production fingerprint and the canonical `openkube-hub.github.io` URL. |

## Test plan

- [x] Image builds and pushes for `linux/amd64` + `linux/arm64` (cross-compiled, no QEMU)
- [x] `cosign verify` against `--certificate-identity-regexp` matching the workflow + tag passes
- [x] `helm pull --verify` against the chart-repo gh-pages site succeeds, with the chart hash matching the signed provenance
- [x] Public key is published to `gh-pages/release-key.asc` on first run (previously silently skipped)
- [x] Re-running the same tag is idempotent (`skip_existing: true` + signature replay)
- [ ] Same flow runs cleanly on `openkube-hub/KubeUser` once `HELM_GPG_KEY` and `HELM_GPG_PASSPHRASE` secrets are configured and `gh-pages` Pages is enabled — recommended to dry-run with a `v0.1.0-rc1` tag before promoting to `v0.1.0`

## Reviewer checklist for merge → first release

Before tagging the first signed release after merge:

1. `HELM_GPG_KEY` and `HELM_GPG_PASSPHRASE` secrets present on `openkube-hub/KubeUser` (private key + passphrase for fingerprint `280EF6E0 A697EF70 F327B63B 28346DDB 12B92C97`)
2. GitHub Pages enabled on the `gh-pages` branch (`gh api repos/openkube-hub/KubeUser/pages` returns 200)
3. GHCR package `openkube-hub/kubeuser-controller` exists and is linked to the repo, **or** a `GHCR_TOKEN` PAT secret with `write:packages` scope is set (the workflow falls back to whichever is available)
4. Tag `v0.1.0-rc1` first; verify both `cosign verify` and `helm pull --verify` succeed; then tag `v0.1.0`