### PR TITLE
feat: make kubeconfig cluster name configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ import (
 
 	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
 	"github.com/openkube-hub/KubeUser/internal/controller"
+	"github.com/openkube-hub/KubeUser/internal/controller/helpers"
 	"github.com/openkube-hub/KubeUser/internal/controller/metrics"
 	"github.com/openkube-hub/KubeUser/internal/validation"
 	webhookpkg "github.com/openkube-hub/KubeUser/internal/webhook"
@@ -120,6 +121,13 @@ func main() {
 		signerName = "kubernetes.io/kube-apiserver-client" // Default for standard K8s
 	}
 	setupLog.Info("Using CSR signer for certificate requests", "signerName", signerName)
+
+	clusterName := helpers.GetKubeconfigClusterName()
+	if err := helpers.ValidateKubeconfigClusterName(clusterName); err != nil {
+		setupLog.Error(err, "invalid kubeconfig cluster name")
+		os.Exit(1)
+	}
+	setupLog.Info("Using kubeconfig cluster name", "clusterName", clusterName)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -216,10 +224,11 @@ func main() {
 	metricsRecorder := metrics.NewRecorder()
 
 	if err := (&controller.UserReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		SignerName: signerName, // Pass configurable signer for managed K8s support
-		Metrics:    metricsRecorder,
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		SignerName:  signerName, // Pass configurable signer for managed K8s support
+		ClusterName: clusterName,
+		Metrics:     metricsRecorder,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "User")
 		os.Exit(1)

--- a/helm/kubeuser/README.md
+++ b/helm/kubeuser/README.md
@@ -63,6 +63,7 @@ authDefaults:
 - `authDefaults.ttl` → `KUBEUSER_DEFAULT_TTL`
 - `authDefaults.autoRenew` → `KUBEUSER_DEFAULT_AUTORENEW`
 - `signerName` → `KUBEUSER_SIGNER_NAME`
+- `clusterName` → `KUBEUSER_CLUSTER_NAME`
 
 **⚠️  Important:** Changes to `authDefaults` only apply to NEW users created after the Helm upgrade. Existing users retain their original defaults (persisted in spec).
 
@@ -122,6 +123,7 @@ The following table lists the configurable parameters and their default values:
 | `env.CLUSTER_DOMAIN` | Kubernetes cluster domain | `cluster.local` |
 | `env.KUBEUSER_MIN_DURATION` | Minimum certificate duration (optional) | `10m` |
 | `env.KUBEUSER_ROTATION_THRESHOLD` | Certificate rotation threshold (optional) | `25% of TTL` |
+| `clusterName` | Cluster and context name written into generated kubeconfigs | `cluster` |
 | `commonLabels.environment` | Common environment label | `test` |
 
 ## Usage Examples

--- a/helm/kubeuser/templates/deployment.yaml
+++ b/helm/kubeuser/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
           value: {{ .Release.Namespace }}
         - name: KUBEUSER_SIGNER_NAME
           value: {{ (.Values.signerName | default "kubernetes.io/kube-apiserver-client") | quote }}
+        - name: KUBEUSER_CLUSTER_NAME
+          value: {{ (.Values.clusterName | default "cluster") | quote }}
         - name: KUBEUSER_DEFAULT_TTL
           value: {{ .Values.authDefaults.ttl | quote }}
         - name: KUBEUSER_DEFAULT_AUTORENEW

--- a/helm/kubeuser/values-example.yaml
+++ b/helm/kubeuser/values-example.yaml
@@ -204,6 +204,9 @@ env:
 # - GKE/AKS/custom:     set to your cluster's signer name
 signerName: "kubernetes.io/kube-apiserver-client"
 
+# Kubeconfig cluster name written into generated kubeconfigs
+clusterName: "production"
+
 # RBAC configuration
 rbac:
   create: true

--- a/helm/kubeuser/values.yaml
+++ b/helm/kubeuser/values.yaml
@@ -179,6 +179,10 @@ env:
 # - GKE/AKS or custom: set to your cluster's signer name
 signerName: "kubernetes.io/kube-apiserver-client"
 
+# Kubeconfig cluster name
+# This controls the cluster and context name written into generated kubeconfigs.
+clusterName: "cluster"
+
 # RBAC configuration
 rbac:
   create: true

--- a/internal/controller/auth/auth.go
+++ b/internal/controller/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	"github.com/openkube-hub/KubeUser/internal/controller/helpers"
 	"github.com/openkube-hub/KubeUser/internal/controller/metrics"
 	certv1 "k8s.io/api/certificates/v1"
 	"k8s.io/client-go/tools/record"
@@ -45,21 +46,26 @@ type Manager struct {
 	x509          Provider
 	oidc          Provider
 	signerName    string // Configurable signer for managed K8s support
+	clusterName   string // Configurable kubeconfig cluster name
 	metrics       *metrics.Recorder
 }
 
 // NewManager creates a new auth manager with the provided client, event recorder, optional signer name, and metrics recorder
-func NewManager(c client.Client, eventRecorder record.EventRecorder, signerName string, metricsRecorder *metrics.Recorder) *Manager {
+func NewManager(c client.Client, eventRecorder record.EventRecorder, signerName, clusterName string, metricsRecorder *metrics.Recorder) *Manager {
 	// Default to standard Kubernetes signer if not specified
 	if signerName == "" {
 		signerName = certv1.KubeAPIServerClientSignerName
 	}
+	if clusterName == "" {
+		clusterName = helpers.DefaultKubeconfigClusterName
+	}
 	return &Manager{
 		client:        c,
 		eventRecorder: eventRecorder,
-		x509:          NewX509Provider(c, eventRecorder, signerName, metricsRecorder),
+		x509:          NewX509Provider(c, eventRecorder, signerName, clusterName, metricsRecorder),
 		oidc:          NewOIDCProvider(c),
 		signerName:    signerName,
+		clusterName:   clusterName,
 		metrics:       metricsRecorder,
 	}
 }

--- a/internal/controller/auth/auth_test.go
+++ b/internal/controller/auth/auth_test.go
@@ -190,7 +190,7 @@ func TestManager(t *testing.T) {
 	_ = authv1alpha1.AddToScheme(scheme)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	manager := NewManager(client, nil, "", nil) // nil event recorder and metrics for tests, default signer
+	manager := NewManager(client, nil, "", "", nil) // nil event recorder and metrics for tests, default signer
 
 	user := &authv1alpha1.User{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/auth/x509.go
+++ b/internal/controller/auth/x509.go
@@ -23,20 +23,25 @@ type X509Provider struct {
 	renewalCalculator *renewal.RenewalCalculator
 	rotationManager   *renewal.RotationManager
 	signerName        string // Configurable signer for managed K8s support
+	clusterName       string // Configurable kubeconfig cluster name
 	metrics           *metrics.Recorder
 }
 
 // NewX509Provider creates a new x509 auth provider with configurable signer
-func NewX509Provider(c client.Client, eventRecorder record.EventRecorder, signerName string, metricsRecorder *metrics.Recorder) *X509Provider {
+func NewX509Provider(c client.Client, eventRecorder record.EventRecorder, signerName, clusterName string, metricsRecorder *metrics.Recorder) *X509Provider {
 	// Default to standard Kubernetes signer if not specified
 	if signerName == "" {
 		signerName = certv1.KubeAPIServerClientSignerName
 	}
+	if clusterName == "" {
+		clusterName = helpers.DefaultKubeconfigClusterName
+	}
 	return &X509Provider{
 		client:            c,
 		renewalCalculator: renewal.NewRenewalCalculator(),
-		rotationManager:   renewal.NewRotationManager(c, eventRecorder, signerName, metricsRecorder),
+		rotationManager:   renewal.NewRotationManager(c, eventRecorder, signerName, clusterName, metricsRecorder),
 		signerName:        signerName,
+		clusterName:       clusterName,
 		metrics:           metricsRecorder,
 	}
 }
@@ -140,7 +145,7 @@ func (p *X509Provider) Ensure(ctx context.Context, user *authv1alpha1.User) (boo
 
 	// Use existing certificate logic for initial creation or non-renewal updates
 	// CRITICAL: Capture statusChanged from certs package to bubble up to orchestrator
-	statusChanged, requeueNeeded, err := certs.EnsureCertKubeconfigWithDuration(ctx, p.client, user, duration, p.signerName)
+	statusChanged, requeueNeeded, err := certs.EnsureCertKubeconfigWithDuration(ctx, p.client, user, duration, p.signerName, p.clusterName)
 	if err != nil {
 		return statusChanged, nil, fmt.Errorf("failed to ensure certificate kubeconfig: %v", err)
 	}

--- a/internal/controller/auth/x509_test.go
+++ b/internal/controller/auth/x509_test.go
@@ -15,7 +15,7 @@ func TestX509Provider_Ensure(t *testing.T) {
 	_ = authv1alpha1.AddToScheme(scheme)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	provider := NewX509Provider(client, nil, "", nil) // nil event recorder and metrics for tests, default signer
+	provider := NewX509Provider(client, nil, "", "", nil) // nil event recorder and metrics for tests, default signer
 
 	user := &authv1alpha1.User{
 		ObjectMeta: metav1.ObjectMeta{
@@ -52,7 +52,7 @@ func TestX509Provider_Revoke(t *testing.T) {
 	_ = authv1alpha1.AddToScheme(scheme)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	provider := NewX509Provider(client, nil, "", nil) // nil event recorder and metrics for tests, default signer
+	provider := NewX509Provider(client, nil, "", "", nil) // nil event recorder and metrics for tests, default signer
 
 	user := &authv1alpha1.User{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/certs/certs.go
+++ b/internal/controller/certs/certs.go
@@ -28,6 +28,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -40,7 +42,7 @@ func EnsureCertKubeconfig(ctx context.Context, r client.Client, user *authv1alph
 	// Use default duration (3 months) and default signer
 	defaultDuration := 90 * 24 * time.Hour
 	defaultSigner := certv1.KubeAPIServerClientSignerName
-	return EnsureCertKubeconfigWithDuration(ctx, r, user, defaultDuration, defaultSigner)
+	return EnsureCertKubeconfigWithDuration(ctx, r, user, defaultDuration, defaultSigner, helpers.DefaultKubeconfigClusterName)
 }
 
 // EnsureCertKubeconfigWithDuration ensures certificate kubeconfig with custom duration and configurable signer.
@@ -50,10 +52,13 @@ func EnsureCertKubeconfig(ctx context.Context, r client.Client, user *authv1alph
 // - error: any execution error
 // This function does NOT perform any r.Status().Update() calls - it only modifies the user object in memory.
 // The caller (orchestrator) is responsible for persisting status changes to etcd.
-func EnsureCertKubeconfigWithDuration(ctx context.Context, r client.Client, user *authv1alpha1.User, duration time.Duration, signerName string) (bool, bool, error) {
+func EnsureCertKubeconfigWithDuration(ctx context.Context, r client.Client, user *authv1alpha1.User, duration time.Duration, signerName, clusterName string) (bool, bool, error) {
 	// Default to standard Kubernetes signer if not specified
 	if signerName == "" {
 		signerName = certv1.KubeAPIServerClientSignerName
+	}
+	if clusterName == "" {
+		clusterName = helpers.DefaultKubeconfigClusterName
 	}
 
 	username := user.Name
@@ -99,7 +104,7 @@ func EnsureCertKubeconfigWithDuration(ctx context.Context, r client.Client, user
 	}
 
 	// Stage 7: Persist kubeconfig secret
-	if err := persistKubeconfig(ctx, r, user, signedCert, keyPEM); err != nil {
+	if err := persistKubeconfig(ctx, r, user, signedCert, keyPEM, clusterName); err != nil {
 		return false, false, fmt.Errorf("failed to persist kubeconfig: %w", err)
 	}
 
@@ -396,7 +401,7 @@ func calculateCertificateMetadata(ctx context.Context, user *authv1alpha1.User, 
 }
 
 // persistKubeconfig gathers CA data, API URL, and builds/saves the final kubeconfig secret
-func persistKubeconfig(ctx context.Context, r client.Client, user *authv1alpha1.User, certPEM, keyPEM []byte) error {
+func persistKubeconfig(ctx context.Context, r client.Client, user *authv1alpha1.User, certPEM, keyPEM []byte, clusterName string) error {
 	logger := logf.FromContext(ctx)
 	username := user.Name
 	userNamespace := helpers.GetKubeUserNamespace()
@@ -421,6 +426,7 @@ func persistKubeconfig(ctx context.Context, r client.Client, user *authv1alpha1.
 		base64.StdEncoding.EncodeToString(certPEM),
 		base64.StdEncoding.EncodeToString(keyPEM),
 		username,
+		clusterName,
 	)
 
 	// Create or update kubeconfig secret
@@ -471,27 +477,47 @@ func getClusterCABase64(ctx context.Context, r client.Client) (string, error) {
 	return "", errors.New("CA not found")
 }
 
-func buildCertKubeconfig(apiServer, caDataB64, certDataB64, keyDataB64, username string) []byte {
-	return []byte(fmt.Sprintf(`apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    certificate-authority-data: %s
-    server: %s
-  name: cluster
-contexts:
-- context:
-    cluster: cluster
-    namespace: default
-    user: %s
-  name: %s@cluster
-current-context: %s@cluster
-users:
-- name: %s
-  user:
-    client-certificate-data: %s
-    client-key-data: %s
-`, caDataB64, apiServer, username, username, username, username, certDataB64, keyDataB64))
+func buildCertKubeconfig(apiServer, caDataB64, certDataB64, keyDataB64, username, clusterName string) []byte {
+	if clusterName == "" {
+		clusterName = helpers.DefaultKubeconfigClusterName
+	}
+	contextName := fmt.Sprintf("%s@%s", username, clusterName)
+	kubeconfig, err := clientcmd.Write(clientcmdapi.Config{
+		Kind:       "Config",
+		APIVersion: "v1",
+		Clusters: map[string]*clientcmdapi.Cluster{
+			clusterName: {
+				Server:                   apiServer,
+				CertificateAuthorityData: decodeBase64OrRaw(caDataB64),
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			username: {
+				ClientCertificateData: decodeBase64OrRaw(certDataB64),
+				ClientKeyData:         decodeBase64OrRaw(keyDataB64),
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			contextName: {
+				Cluster:   clusterName,
+				AuthInfo:  username,
+				Namespace: "default",
+			},
+		},
+		CurrentContext: contextName,
+	})
+	if err != nil {
+		return []byte{}
+	}
+	return kubeconfig
+}
+
+func decodeBase64OrRaw(value string) []byte {
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return []byte(value)
+	}
+	return decoded
 }
 
 // extractCertificateExpiryWithFormatDetection tries multiple formats to extract certificate expiry
@@ -679,10 +705,16 @@ func GetAPIServerURL() string {
 
 // BuildCertKubeconfig builds a kubeconfig with certificate authentication (exported for renewal package)
 func BuildCertKubeconfig(apiServer, caDataB64 string, signedCert, keyPEM []byte, username string) []byte {
+	return BuildCertKubeconfigWithClusterName(apiServer, caDataB64, signedCert, keyPEM, username, helpers.DefaultKubeconfigClusterName)
+}
+
+// BuildCertKubeconfigWithClusterName builds a kubeconfig with a configurable cluster name.
+func BuildCertKubeconfigWithClusterName(apiServer, caDataB64 string, signedCert, keyPEM []byte, username, clusterName string) []byte {
 	return buildCertKubeconfig(apiServer, caDataB64,
 		base64.StdEncoding.EncodeToString(signedCert),
 		base64.StdEncoding.EncodeToString(keyPEM),
-		username)
+		username,
+		clusterName)
 }
 
 // ExtractCertificateExpiryWithFormatDetection extracts certificate expiry (exported for renewal package)

--- a/internal/controller/certs/certs_test.go
+++ b/internal/controller/certs/certs_test.go
@@ -163,6 +163,8 @@ func TestBuildCertKubeconfig(t *testing.T) {
 					"users:",
 					"contexts:",
 					"current-context:",
+					"  name: cluster",
+					"    cluster: cluster",
 				}
 
 				for _, expected := range expectedStrings {
@@ -172,6 +174,29 @@ func TestBuildCertKubeconfig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildCertKubeconfigWithClusterName(t *testing.T) {
+	got := string(BuildCertKubeconfigWithClusterName(
+		"https://kubernetes.default.svc",
+		"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
+		[]byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t"),
+		[]byte("LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t"),
+		"alice",
+		"production",
+	))
+
+	expectedStrings := []string{
+		"  name: production",
+		"    cluster: production",
+		"  name: alice@production",
+		"current-context: alice@production",
+	}
+	for _, expected := range expectedStrings {
+		if !contains(got, expected) {
+			t.Errorf("BuildCertKubeconfigWithClusterName() missing expected string: %s", expected)
+		}
 	}
 }
 

--- a/internal/controller/helpers/helpers.go
+++ b/internal/controller/helpers/helpers.go
@@ -10,7 +10,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
+	"unicode"
 
 	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -31,6 +33,8 @@ const (
 	PhaseRenewing = "Renewing"
 )
 
+const DefaultKubeconfigClusterName = "cluster"
+
 // GetAutoRenew returns the autoRenew value with default of true if not specified
 func GetAutoRenew(user *authv1alpha1.User) bool {
 	if user.Spec.Auth == nil {
@@ -49,6 +53,31 @@ func GetKubeUserNamespace() string {
 		namespace = "kubeuser" // fallback to default
 	}
 	return namespace
+}
+
+// GetKubeconfigClusterName returns the cluster name used in generated kubeconfigs.
+func GetKubeconfigClusterName() string {
+	clusterName := os.Getenv("KUBEUSER_CLUSTER_NAME")
+	if clusterName == "" {
+		return DefaultKubeconfigClusterName
+	}
+	return clusterName
+}
+
+// ValidateKubeconfigClusterName rejects blank names and control characters.
+func ValidateKubeconfigClusterName(clusterName string) error {
+	if clusterName == "" {
+		return fmt.Errorf("cluster name must not be empty")
+	}
+	if strings.TrimSpace(clusterName) != clusterName {
+		return fmt.Errorf("cluster name must not have leading or trailing whitespace")
+	}
+	for _, r := range clusterName {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("cluster name %q contains unsupported character %q", clusterName, r)
+		}
+	}
+	return nil
 }
 
 func CreateOrUpdate(ctx context.Context, r client.Client, obj client.Object) error {

--- a/internal/controller/helpers/helpers.go
+++ b/internal/controller/helpers/helpers.go
@@ -12,13 +12,13 @@ import (
 	"os"
 	"strings"
 	"time"
-	"unicode"
 
 	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -64,18 +64,16 @@ func GetKubeconfigClusterName() string {
 	return clusterName
 }
 
-// ValidateKubeconfigClusterName rejects blank names and control characters.
+// ValidateKubeconfigClusterName enforces the DNS-1123 label rule
+// (^[a-z0-9]([-a-z0-9]*[a-z0-9])?$, at most 63 characters) so that generated
+// kubeconfig cluster and context names are safe for downstream tooling
+// (kubectl, kubectx, GitOps flows) that assume DNS-safe identifiers.
 func ValidateKubeconfigClusterName(clusterName string) error {
 	if clusterName == "" {
 		return fmt.Errorf("cluster name must not be empty")
 	}
-	if strings.TrimSpace(clusterName) != clusterName {
-		return fmt.Errorf("cluster name must not have leading or trailing whitespace")
-	}
-	for _, r := range clusterName {
-		if unicode.IsControl(r) {
-			return fmt.Errorf("cluster name %q contains unsupported character %q", clusterName, r)
-		}
+	if errs := validation.IsDNS1123Label(clusterName); len(errs) > 0 {
+		return fmt.Errorf("cluster name %q is not a valid DNS-1123 label: %s", clusterName, strings.Join(errs, "; "))
 	}
 	return nil
 }

--- a/internal/controller/helpers/helpers_test.go
+++ b/internal/controller/helpers/helpers_test.go
@@ -1,6 +1,9 @@
 package helpers
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGetKubeconfigClusterNameDefault(t *testing.T) {
 	t.Setenv("KUBEUSER_CLUSTER_NAME", "")
@@ -24,6 +27,7 @@ func TestValidateKubeconfigClusterName(t *testing.T) {
 		clusterName string
 		wantErr     bool
 	}{
+		// Accepted: DNS-1123 labels.
 		{
 			name:        "default",
 			clusterName: DefaultKubeconfigClusterName,
@@ -35,8 +39,54 @@ func TestValidateKubeconfigClusterName(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name:        "hyphenated region",
+			clusterName: "prod-eu-west-1",
+			wantErr:     false,
+		},
+		{
+			name:        "single character",
+			clusterName: "a",
+			wantErr:     false,
+		},
+		{
+			name:        "max length 63",
+			clusterName: strings.Repeat("a", 63),
+			wantErr:     false,
+		},
+		// Rejected: violations of the DNS-1123 label rule.
+		{
 			name:        "empty",
 			clusterName: "",
+			wantErr:     true,
+		},
+		{
+			name:        "uppercase",
+			clusterName: "Production",
+			wantErr:     true,
+		},
+		{
+			name:        "all uppercase",
+			clusterName: "PROD",
+			wantErr:     true,
+		},
+		{
+			name:        "underscore",
+			clusterName: "prod_east",
+			wantErr:     true,
+		},
+		{
+			name:        "over 63 characters",
+			clusterName: strings.Repeat("a", 64),
+			wantErr:     true,
+		},
+		{
+			name:        "leading hyphen",
+			clusterName: "-prod",
+			wantErr:     true,
+		},
+		{
+			name:        "trailing hyphen",
+			clusterName: "prod-",
 			wantErr:     true,
 		},
 		{
@@ -47,17 +97,22 @@ func TestValidateKubeconfigClusterName(t *testing.T) {
 		{
 			name:        "embedded whitespace",
 			clusterName: "prod east",
-			wantErr:     false,
+			wantErr:     true,
 		},
 		{
 			name:        "context separator",
 			clusterName: "prod@east",
-			wantErr:     false,
+			wantErr:     true,
 		},
 		{
 			name:        "yaml separator",
 			clusterName: "prod:east",
-			wantErr:     false,
+			wantErr:     true,
+		},
+		{
+			name:        "dot separator",
+			clusterName: "prod.east",
+			wantErr:     true,
 		},
 		{
 			name:        "newline",

--- a/internal/controller/helpers/helpers_test.go
+++ b/internal/controller/helpers/helpers_test.go
@@ -1,0 +1,77 @@
+package helpers
+
+import "testing"
+
+func TestGetKubeconfigClusterNameDefault(t *testing.T) {
+	t.Setenv("KUBEUSER_CLUSTER_NAME", "")
+
+	if got := GetKubeconfigClusterName(); got != DefaultKubeconfigClusterName {
+		t.Fatalf("GetKubeconfigClusterName() = %q, want %q", got, DefaultKubeconfigClusterName)
+	}
+}
+
+func TestGetKubeconfigClusterNameCustom(t *testing.T) {
+	t.Setenv("KUBEUSER_CLUSTER_NAME", "production")
+
+	if got := GetKubeconfigClusterName(); got != "production" {
+		t.Fatalf("GetKubeconfigClusterName() = %q, want production", got)
+	}
+}
+
+func TestValidateKubeconfigClusterName(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		wantErr     bool
+	}{
+		{
+			name:        "default",
+			clusterName: DefaultKubeconfigClusterName,
+			wantErr:     false,
+		},
+		{
+			name:        "custom",
+			clusterName: "production",
+			wantErr:     false,
+		},
+		{
+			name:        "empty",
+			clusterName: "",
+			wantErr:     true,
+		},
+		{
+			name:        "leading whitespace",
+			clusterName: " production",
+			wantErr:     true,
+		},
+		{
+			name:        "embedded whitespace",
+			clusterName: "prod east",
+			wantErr:     false,
+		},
+		{
+			name:        "context separator",
+			clusterName: "prod@east",
+			wantErr:     false,
+		},
+		{
+			name:        "yaml separator",
+			clusterName: "prod:east",
+			wantErr:     false,
+		},
+		{
+			name:        "newline",
+			clusterName: "prod\neast",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateKubeconfigClusterName(tt.clusterName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateKubeconfigClusterName(%q) error = %v, wantErr %v", tt.clusterName, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/controller/renewal/renewal_test.go
+++ b/internal/controller/renewal/renewal_test.go
@@ -101,7 +101,7 @@ func TestRenewalCalculator_ShouldRenewNow_Basic(t *testing.T) {
 }
 
 func TestRotationManager_CSRName(t *testing.T) {
-	rm := NewRotationManager(nil, nil, "", nil)
+	rm := NewRotationManager(nil, nil, "", "", nil)
 
 	csrName := rm.generateUniqueCSRName("alice", "12345678-1234-1234-1234-123456789012")
 	expected := "alice-renewal-12345678"
@@ -112,7 +112,7 @@ func TestRotationManager_CSRName(t *testing.T) {
 }
 
 func TestRotationManager_RequeueDelay(t *testing.T) {
-	rm := NewRotationManager(nil, nil, "", nil)
+	rm := NewRotationManager(nil, nil, "", "", nil)
 
 	tests := []struct {
 		name         string

--- a/internal/controller/renewal/rotation.go
+++ b/internal/controller/renewal/rotation.go
@@ -54,19 +54,24 @@ type RotationManager struct {
 	client        client.Client
 	eventRecorder record.EventRecorder
 	signerName    string // Configurable signer for managed K8s support (EKS, GKE, AKS)
+	clusterName   string // Configurable kubeconfig cluster name
 	metrics       *metrics.Recorder
 }
 
 // NewRotationManager creates a new rotation manager with configurable signer
-func NewRotationManager(k8sClient client.Client, eventRecorder record.EventRecorder, signerName string, metricsRecorder *metrics.Recorder) *RotationManager {
+func NewRotationManager(k8sClient client.Client, eventRecorder record.EventRecorder, signerName, clusterName string, metricsRecorder *metrics.Recorder) *RotationManager {
 	// Default to standard Kubernetes signer if not specified
 	if signerName == "" {
 		signerName = certv1.KubeAPIServerClientSignerName
+	}
+	if clusterName == "" {
+		clusterName = helpers.DefaultKubeconfigClusterName
 	}
 	return &RotationManager{
 		client:        k8sClient,
 		eventRecorder: eventRecorder,
 		signerName:    signerName,
+		clusterName:   clusterName,
 		metrics:       metricsRecorder,
 	}
 }
@@ -867,7 +872,7 @@ func (rm *RotationManager) getAPIServerURL() string {
 
 func (rm *RotationManager) buildKubeconfig(apiServer, caDataB64 string, signedCert, keyPEM []byte, username string) []byte {
 	// Use the existing implementation from certs package
-	return certs.BuildCertKubeconfig(apiServer, caDataB64, signedCert, keyPEM, username)
+	return certs.BuildCertKubeconfigWithClusterName(apiServer, caDataB64, signedCert, keyPEM, username, rm.clusterName)
 }
 
 func (rm *RotationManager) extractCertificateExpiry(certData []byte) (time.Time, error) {

--- a/internal/controller/renewal/rotation_test.go
+++ b/internal/controller/renewal/rotation_test.go
@@ -2,6 +2,7 @@ package renewal
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func TestRotationManager_generateUniqueCSRName(t *testing.T) {
-	rm := NewRotationManager(nil, nil, "", nil)
+	rm := NewRotationManager(nil, nil, "", "", nil)
 
 	tests := []struct {
 		name     string
@@ -49,6 +50,30 @@ func TestRotationManager_generateUniqueCSRName(t *testing.T) {
 				t.Errorf("generateUniqueCSRName() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRotationManagerBuildKubeconfigUsesConfiguredClusterName(t *testing.T) {
+	rm := NewRotationManager(nil, nil, "", "production", nil)
+
+	got := string(rm.buildKubeconfig(
+		"https://kubernetes.default.svc",
+		"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
+		[]byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t"),
+		[]byte("LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t"),
+		"alice",
+	))
+
+	expectedStrings := []string{
+		"  name: production",
+		"    cluster: production",
+		"  name: alice@production",
+		"current-context: alice@production",
+	}
+	for _, expected := range expectedStrings {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("buildKubeconfig() missing expected string %q in:\n%s", expected, got)
+		}
 	}
 }
 
@@ -132,7 +157,7 @@ func TestRotationManager_IsRotationInProgress(t *testing.T) {
 				WithRuntimeObjects(objects...).
 				Build()
 
-			rm := NewRotationManager(client, nil, "", nil)
+			rm := NewRotationManager(client, nil, "", "", nil)
 
 			gotInProgress, gotCSRName, err := rm.IsRotationInProgress(context.TODO(), tt.username)
 
@@ -153,7 +178,7 @@ func TestRotationManager_IsRotationInProgress(t *testing.T) {
 }
 
 func TestRotationManager_GetRotationRequeueDelay(t *testing.T) {
-	rm := NewRotationManager(nil, nil, "", nil)
+	rm := NewRotationManager(nil, nil, "", "", nil)
 
 	tests := []struct {
 		name         string
@@ -193,7 +218,7 @@ func TestRotationManager_GetRotationRequeueDelay(t *testing.T) {
 }
 
 func TestRotationManager_recordUniqueAttempt_Basic(t *testing.T) {
-	rm := NewRotationManager(nil, nil, "", nil)
+	rm := NewRotationManager(nil, nil, "", "", nil)
 
 	// Test basic functionality - adding first attempt
 	user := &authv1alpha1.User{
@@ -221,7 +246,7 @@ func TestRotationManager_recordUniqueAttempt_Basic(t *testing.T) {
 }
 
 func TestRotationManager_validateCSRForApproval(t *testing.T) {
-	rm := NewRotationManager(nil, nil, "", nil)
+	rm := NewRotationManager(nil, nil, "", "", nil)
 
 	tests := []struct {
 		name    string
@@ -370,7 +395,7 @@ func TestRotationManager_IsRotationInProgress_RoundTripsCSRName(t *testing.T) {
 	}
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
-	rm := NewRotationManager(cli, nil, "kubernetes.io/kube-apiserver-client", nil)
+	rm := NewRotationManager(cli, nil, "kubernetes.io/kube-apiserver-client", "", nil)
 
 	user := &authv1alpha1.User{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -39,6 +39,7 @@ type UserReconciler struct {
 	AuthManager       *auth.Manager
 	RenewalCalculator *renewal.RenewalCalculator
 	SignerName        string // Configurable CSR signer for managed K8s support (EKS, GKE, AKS)
+	ClusterName       string // Configurable kubeconfig cluster name
 	Metrics           *metrics.Recorder
 }
 
@@ -364,7 +365,7 @@ func (r *UserReconciler) reconcileAuthentication(ctx context.Context, user *auth
 
 	// Initialize auth manager if needed
 	if r.AuthManager == nil {
-		r.AuthManager = auth.NewManager(r.Client, r.EventRecorder, r.SignerName, r.Metrics)
+		r.AuthManager = auth.NewManager(r.Client, r.EventRecorder, r.SignerName, r.ClusterName, r.Metrics)
 	}
 
 	// Capture old values before authentication processing
@@ -696,10 +697,13 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.SignerName == "" {
 		r.SignerName = "kubernetes.io/kube-apiserver-client"
 	}
+	if r.ClusterName == "" {
+		r.ClusterName = helpers.DefaultKubeconfigClusterName
+	}
 
 	// Initialize auth manager with configurable signer
 	if r.AuthManager == nil {
-		r.AuthManager = auth.NewManager(r.Client, r.EventRecorder, r.SignerName, r.Metrics)
+		r.AuthManager = auth.NewManager(r.Client, r.EventRecorder, r.SignerName, r.ClusterName, r.Metrics)
 	}
 
 	// Initialize renewal calculator


### PR DESCRIPTION
## Summary

- add a `clusterName` Helm value that maps to `KUBEUSER_CLUSTER_NAME`
- validate the configured cluster name at startup and thread it through initial certificate issuance and renewal
- generate kubeconfigs via Kubernetes `clientcmd.Write` with the configured cluster/context name

Closes #88.

## Verification

- `go test ./internal/controller/helpers ./internal/controller/certs ./internal/controller/renewal ./internal/controller/auth`
- `GOPROXY=https://proxy.golang.org,direct make test`
- `helm lint ./helm/kubeuser`
- `helm template kubeuser ./helm/kubeuser | rg -n "KUBEUSER_CLUSTER_NAME|value: \"cluster\""`
- `helm template kubeuser ./helm/kubeuser --set clusterName=production | rg -n "KUBEUSER_CLUSTER_NAME|value: \"production\""`
- `git diff --check`
