### PR TITLE
fix(rbac): reject duplicate role/clusterRole bindings instead of silently dropping

### DIFF
--- a/api/v1alpha1/rolespec.go
+++ b/api/v1alpha1/rolespec.go
@@ -1,0 +1,13 @@
+package v1alpha1
+
+// BindingKey returns the uniqueness identity of a role entry:
+// namespace + the effective role name (whichever of ExistingRole /
+// ExistingClusterRole is set). Used by the admission webhook and the
+// controller so both agree on what "duplicate" means.
+func (r RoleSpec) BindingKey() string {
+	name := r.ExistingRole
+	if name == "" {
+		name = r.ExistingClusterRole
+	}
+	return r.Namespace + ":" + name
+}

--- a/api/v1alpha1/user_types.go
+++ b/api/v1alpha1/user_types.go
@@ -12,16 +12,19 @@ import (
 type RoleSpec struct {
 	// Namespace where the RoleBinding will be created
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Namespace string `json:"namespace"`
 
 	// ExistingRole is the name of the Role inside that namespace
 	// Mutually exclusive with ExistingClusterRole
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
 	ExistingRole string `json:"existingRole,omitempty"`
 
 	// ExistingClusterRole is the name of a ClusterRole to bind with a RoleBinding in the namespace
 	// Mutually exclusive with ExistingRole
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
 	ExistingClusterRole string `json:"existingClusterRole,omitempty"`
 }
 
@@ -29,6 +32,7 @@ type RoleSpec struct {
 type ClusterRoleSpec struct {
 	// ExistingClusterRole is the name of the ClusterRole to bind
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	ExistingClusterRole string `json:"existingClusterRole"`
 }
 
@@ -63,12 +67,22 @@ type UserSpec struct {
 	// +kubebuilder:validation:Required
 	Auth *AuthSpec `json:"auth"`
 
-	// Roles is a list of namespace-scoped Role bindings
+	// Roles is a list of namespace-scoped Role bindings. Uniqueness per
+	// (namespace, role) is enforced by the webhook and controller via
+	// RoleSpec.BindingKey — a composite key can't be a CRD listMapKey, so it
+	// lives in code. MaxItems is a deliberate object-size/DoS bound.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Roles []RoleSpec `json:"roles,omitempty"`
 
-	// ClusterRoles is a list of cluster-wide ClusterRole bindings
+	// ClusterRoles is a list of cluster-wide ClusterRole bindings. listType=map
+	// makes the apiserver enforce uniqueness of existingClusterRole natively
+	// (rejected at admission, cannot be bypassed) and enables per-entry
+	// server-side apply. MaxItems is a deliberate object-size/DoS bound.
 	// +optional
+	// +listType=map
+	// +listMapKey=existingClusterRole
+	// +kubebuilder:validation:MaxItems=100
 	ClusterRoles []ClusterRoleSpec `json:"clusterRoles,omitempty"`
 }
 

--- a/config/crd/bases/auth.openkube.io_users.yaml
+++ b/config/crd/bases/auth.openkube.io_users.yaml
@@ -95,7 +95,11 @@ spec:
                 - type
                 type: object
               clusterRoles:
-                description: ClusterRoles is a list of cluster-wide ClusterRole bindings
+                description: |-
+                  ClusterRoles is a list of cluster-wide ClusterRole bindings. listType=map
+                  makes the apiserver enforce uniqueness of existingClusterRole natively
+                  (rejected at admission, cannot be bypassed) and enables per-entry
+                  server-side apply. MaxItems is a deliberate object-size/DoS bound.
                 items:
                   description: ClusterRoleSpec defines cluster-wide access by binding
                     to an existing ClusterRole
@@ -103,14 +107,23 @@ spec:
                     existingClusterRole:
                       description: ExistingClusterRole is the name of the ClusterRole
                         to bind
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:
                   - existingClusterRole
                   type: object
+                maxItems: 100
                 type: array
+                x-kubernetes-list-map-keys:
+                - existingClusterRole
+                x-kubernetes-list-type: map
               roles:
-                description: Roles is a list of namespace-scoped Role bindings
+                description: |-
+                  Roles is a list of namespace-scoped Role bindings. Uniqueness per
+                  (namespace, role) is enforced by the webhook and controller via
+                  RoleSpec.BindingKey — a composite key can't be a CRD listMapKey, so it
+                  lives in code. MaxItems is a deliberate object-size/DoS bound.
                 items:
                   description: RoleSpec defines namespace-scoped access by binding
                     to an existing Role or ClusterRole
@@ -119,19 +132,23 @@ spec:
                       description: |-
                         ExistingClusterRole is the name of a ClusterRole to bind with a RoleBinding in the namespace
                         Mutually exclusive with ExistingRole
+                      maxLength: 253
                       type: string
                     existingRole:
                       description: |-
                         ExistingRole is the name of the Role inside that namespace
                         Mutually exclusive with ExistingClusterRole
+                      maxLength: 253
                       type: string
                     namespace:
                       description: Namespace where the RoleBinding will be created
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:
                   - namespace
                   type: object
+                maxItems: 100
                 type: array
             required:
             - auth

--- a/helm/kubeuser/templates/crd.yaml
+++ b/helm/kubeuser/templates/crd.yaml
@@ -98,7 +98,11 @@ spec:
                 - type
                 type: object
               clusterRoles:
-                description: ClusterRoles is a list of cluster-wide ClusterRole bindings
+                description: |-
+                  ClusterRoles is a list of cluster-wide ClusterRole bindings. listType=map
+                  makes the apiserver enforce uniqueness of existingClusterRole natively
+                  (rejected at admission, cannot be bypassed) and enables per-entry
+                  server-side apply. MaxItems is a deliberate object-size/DoS bound.
                 items:
                   description: ClusterRoleSpec defines cluster-wide access by binding
                     to an existing ClusterRole
@@ -106,14 +110,23 @@ spec:
                     existingClusterRole:
                       description: ExistingClusterRole is the name of the ClusterRole
                         to bind
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:
                   - existingClusterRole
                   type: object
+                maxItems: 100
                 type: array
+                x-kubernetes-list-map-keys:
+                - existingClusterRole
+                x-kubernetes-list-type: map
               roles:
-                description: Roles is a list of namespace-scoped Role bindings
+                description: |-
+                  Roles is a list of namespace-scoped Role bindings. Uniqueness per
+                  (namespace, role) is enforced by the webhook and controller via
+                  RoleSpec.BindingKey — a composite key can't be a CRD listMapKey, so it
+                  lives in code. MaxItems is a deliberate object-size/DoS bound.
                 items:
                   description: RoleSpec defines namespace-scoped access by binding
                     to an existing Role or ClusterRole
@@ -122,19 +135,23 @@ spec:
                       description: |-
                         ExistingClusterRole is the name of a ClusterRole to bind with a RoleBinding in the namespace
                         Mutually exclusive with ExistingRole
+                      maxLength: 253
                       type: string
                     existingRole:
                       description: |-
                         ExistingRole is the name of the Role inside that namespace
                         Mutually exclusive with ExistingClusterRole
+                      maxLength: 253
                       type: string
                     namespace:
                       description: Namespace where the RoleBinding will be created
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:
                   - namespace
                   type: object
+                maxItems: 100
                 type: array
             required:
             - auth
@@ -224,7 +241,8 @@ spec:
                   description: RenewalAttempt tracks a single renewal attempt
                   properties:
                     csrName:
-                      description: CSRName is the name of the CSR created for this renewal
+                      description: CSRName is the name of the CSR created for this
+                        renewal
                       type: string
                     message:
                       description: Message provides details about the renewal attempt

--- a/internal/controller/rbac/bindings.go
+++ b/internal/controller/rbac/bindings.go
@@ -42,7 +42,17 @@ func ReconcileRoleBindings(ctx context.Context, r client.Client, user *authv1alp
 			return fmt.Errorf("cannot specify both existingRole and existingClusterRole for namespace %s", role.Namespace)
 		}
 
-		var key string
+		// Identity of this role entry. Shared with the admission webhook via
+		// RoleSpec.BindingKey so both agree on what "duplicate" means.
+		key := role.BindingKey()
+
+		// Backstop for the webhook's duplicate check: catches Users that
+		// bypassed admission (pre-existing objects, etcd restore). Fail loud
+		// rather than silently overwriting (issue #57).
+		if _, dup := desiredRBs[key]; dup {
+			return fmt.Errorf("duplicate spec.roles entry %q appears more than once", key)
+		}
+
 		if role.ExistingRole != "" {
 			// Validate that the Role exists
 			var roleObj rbacv1.Role
@@ -52,7 +62,6 @@ func ReconcileRoleBindings(ctx context.Context, r client.Client, user *authv1alp
 				}
 				return fmt.Errorf("failed to get role %s in namespace %s: %w", role.ExistingRole, role.Namespace, err)
 			}
-			key = fmt.Sprintf("%s:%s", role.Namespace, role.ExistingRole)
 		} else {
 			// Validate that the ClusterRole exists
 			var clusterRoleObj rbacv1.ClusterRole
@@ -62,7 +71,6 @@ func ReconcileRoleBindings(ctx context.Context, r client.Client, user *authv1alp
 				}
 				return fmt.Errorf("failed to get clusterrole %s: %w", role.ExistingClusterRole, err)
 			}
-			key = fmt.Sprintf("%s:%s", role.Namespace, role.ExistingClusterRole)
 		}
 		desiredRBs[key] = role
 	}
@@ -157,6 +165,12 @@ func ReconcileClusterRoleBindings(ctx context.Context, r client.Client, user *au
 	// Create a map of desired ClusterRoleBindings (clusterRole -> ClusterRoleSpec)
 	desiredCRBs := make(map[string]authv1alpha1.ClusterRoleSpec)
 	for _, clusterRole := range user.Spec.ClusterRoles {
+		// Backstop for the listType=map uniqueness rule: catches objects that
+		// bypassed admission. Fail loud rather than silently overwriting.
+		if _, dup := desiredCRBs[clusterRole.ExistingClusterRole]; dup {
+			return fmt.Errorf("duplicate spec.clusterRoles entry: clusterRole %q appears more than once", clusterRole.ExistingClusterRole)
+		}
+
 		// Validate that the ClusterRole exists
 		var crObj rbacv1.ClusterRole
 		if err := r.Get(ctx, types.NamespacedName{Name: clusterRole.ExistingClusterRole}, &crObj); err != nil {

--- a/internal/controller/rbac/bindings_test.go
+++ b/internal/controller/rbac/bindings_test.go
@@ -1,0 +1,143 @@
+package rbac
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func bindingsScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{rbacv1.AddToScheme, authv1alpha1.AddToScheme} {
+		if err := add(s); err != nil {
+			t.Fatalf("scheme: %v", err)
+		}
+	}
+	return s
+}
+
+func testUser(roles []authv1alpha1.RoleSpec, clusterRoles []authv1alpha1.ClusterRoleSpec) *authv1alpha1.User {
+	return &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice", UID: "uid-alice"},
+		Spec:       authv1alpha1.UserSpec{Roles: roles, ClusterRoles: clusterRoles},
+	}
+}
+
+func TestReconcileRoleBindings_RejectsDuplicates(t *testing.T) {
+	// Referenced roles must exist so the first entry's existence check passes.
+	seed := []client.Object{
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "dev"}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "dev"}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "dev"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "shared"}},
+	}
+
+	tests := []struct {
+		name      string
+		roles     []authv1alpha1.RoleSpec
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name:    "exact duplicate role",
+			roles:   []authv1alpha1.RoleSpec{{Namespace: "dev", ExistingRole: "a"}, {Namespace: "dev", ExistingRole: "a"}},
+			wantErr: true,
+		},
+		{
+			name:    "Role and ClusterRole same name+namespace (case B)",
+			roles:   []authv1alpha1.RoleSpec{{Namespace: "dev", ExistingRole: "shared"}, {Namespace: "dev", ExistingClusterRole: "shared"}},
+			wantErr: true,
+		},
+		{
+			name:      "distinct roles",
+			roles:     []authv1alpha1.RoleSpec{{Namespace: "dev", ExistingRole: "a"}, {Namespace: "dev", ExistingRole: "b"}},
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name:    "duplicate regardless of order",
+			roles:   []authv1alpha1.RoleSpec{{Namespace: "dev", ExistingRole: "a"}, {Namespace: "dev", ExistingRole: "b"}, {Namespace: "dev", ExistingRole: "a"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().WithScheme(bindingsScheme(t)).WithObjects(seed...).Build()
+			err := ReconcileRoleBindings(context.Background(), cli, testUser(tt.roles, nil))
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "duplicate") {
+				t.Fatalf("expected a duplicate error, got: %v", err)
+			}
+			if !tt.wantErr {
+				var rbs rbacv1.RoleBindingList
+				if err := cli.List(context.Background(), &rbs, client.MatchingLabels{authv1alpha1.UserLabel: "alice"}); err != nil {
+					t.Fatalf("list: %v", err)
+				}
+				if len(rbs.Items) != tt.wantCount {
+					t.Errorf("RoleBindings = %d, want %d", len(rbs.Items), tt.wantCount)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileClusterRoleBindings_RejectsDuplicates(t *testing.T) {
+	seed := []client.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "view"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "edit"}},
+	}
+
+	tests := []struct {
+		name         string
+		clusterRoles []authv1alpha1.ClusterRoleSpec
+		wantErr      bool
+		wantCount    int
+	}{
+		{
+			name:         "duplicate clusterRole",
+			clusterRoles: []authv1alpha1.ClusterRoleSpec{{ExistingClusterRole: "view"}, {ExistingClusterRole: "view"}},
+			wantErr:      true,
+		},
+		{
+			name:         "distinct clusterRoles",
+			clusterRoles: []authv1alpha1.ClusterRoleSpec{{ExistingClusterRole: "view"}, {ExistingClusterRole: "edit"}},
+			wantErr:      false,
+			wantCount:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().WithScheme(bindingsScheme(t)).WithObjects(seed...).Build()
+			err := ReconcileClusterRoleBindings(context.Background(), cli, testUser(nil, tt.clusterRoles))
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "duplicate") {
+				t.Fatalf("expected a duplicate error, got: %v", err)
+			}
+			if !tt.wantErr {
+				var crbs rbacv1.ClusterRoleBindingList
+				if err := cli.List(context.Background(), &crbs, client.MatchingLabels{authv1alpha1.UserLabel: "alice"}); err != nil {
+					t.Fatalf("list: %v", err)
+				}
+				if len(crbs.Items) != tt.wantCount {
+					t.Errorf("ClusterRoleBindings = %d, want %d", len(crbs.Items), tt.wantCount)
+				}
+			}
+		})
+	}
+}

--- a/internal/webhook/user_webhook.go
+++ b/internal/webhook/user_webhook.go
@@ -162,6 +162,7 @@ func (w *UserWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (a
 
 // validateRoles checks that all referenced Roles or ClusterRoles exist in their respective namespaces
 func (w *UserWebhook) validateRoles(ctx context.Context, roles []authv1alpha1.RoleSpec) error {
+	seen := make(map[string]bool)
 	for _, roleSpec := range roles {
 		// Validate that exactly one of ExistingRole or ExistingClusterRole is set
 		if roleSpec.ExistingRole == "" && roleSpec.ExistingClusterRole == "" {
@@ -173,6 +174,11 @@ func (w *UserWebhook) validateRoles(ctx context.Context, roles []authv1alpha1.Ro
 				roleSpec.Namespace)
 		}
 
+		key := roleSpec.BindingKey()
+		if seen[key] {
+			return fmt.Errorf("duplicate role binding %q in spec.roles", key)
+		}
+		seen[key] = true
 		if roleSpec.ExistingRole != "" {
 			// Validate namespace-scoped Role
 			var role rbacv1.Role
@@ -211,6 +217,8 @@ func (w *UserWebhook) validateRoles(ctx context.Context, roles []authv1alpha1.Ro
 
 // validateClusterRoles checks that all referenced ClusterRoles exist
 func (w *UserWebhook) validateClusterRoles(ctx context.Context, clusterRoles []authv1alpha1.ClusterRoleSpec) error {
+	// Duplicate clusterRoles are rejected natively by the apiserver via
+	// listType=map on spec.clusterRoles, so no dedup check is needed here.
 	for _, clusterRoleSpec := range clusterRoles {
 		var clusterRole rbacv1.ClusterRole
 		err := w.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
## Summary

`ReconcileRoleBindings`/`ReconcileClusterRoleBindings` built their desired-state
maps keyed on `namespace:role` (and `clusterRole`). When a User's spec contained
two entries that resolved to the same key, the second **silently overwrote** the
first — no error, no log, no status condition. The user asked for two grants and
got one, and was told nothing.

The most damaging case: a namespaced `Role` and a `ClusterRole` of the **same
name in the same namespace** collapse to one key (`dev:shared`) *and* to one
generated object name (`<user>-shared-rb`), so the system fundamentally cannot
represent both. Silently picking one is the wrong answer.

This PR makes duplicates a **hard, visible error** at every layer.

Closes #57

## Design

Enforcement is placed where it is strongest for each field, with a uniform
controller backstop:

| Concern | `spec.clusterRoles` | `spec.roles` |
|---|---|---|
| Admission | **native** `listType=map` / `listMapKey` (apiserver-enforced, cannot be bypassed) | **validating webhook** (composite key — see "Why not CEL") |
| Reconcile backstop | controller returns an error | controller returns an error |
| Uniqueness key | the field itself | `RoleSpec.BindingKey()` — the single definition shared by webhook **and** controller |
| Size bound | `MaxItems=100` (deliberate DoS/object-size bound) | `MaxItems=100` |

Defense in depth: admission rejects bad specs before they persist; the controller
backstop catches anything that predates the schema/webhook (etcd restore, upgrade
window, admission bypass) and fails loud instead of silently dropping.

## Why not a CEL `XValidation` rule (deviation from the issue text)

The issue suggested a CEL rule on `spec.roles`. We implemented it, then removed
it — backed by evidence, not preference:

- The `roles` uniqueness key is **composite** (`namespace` + whichever of
  `existingRole`/`existingClusterRole` is set). Expressing that in CEL requires a
  derived key, and the apiserver's CEL **cost estimator rejected every
  formulation by >100x** — including a `has()`-guarded 4-term direct-field
  comparison, **even with `maxItems` lowered to 2** and `maxLength: 253` present.
  The estimator does not propagate string-length bounds through these
  expressions, so it costs the comparisons as effectively unbounded.
- The single-field `clusterRoles` rule *does* fit the budget — which is exactly
  why `clusterRoles` uses the native `listType=map` (cleaner than CEL: free,
  unbypassable, and it also gives correct server-side-apply merge semantics).
- For the composite `roles` key, the validating webhook is the right tool: it
  reuses the **same `BindingKey()`** the controller uses, so there is a single
  source of truth and no admission/reconcile drift.

## Changes

- **`api/v1alpha1/rolespec.go`** *(new)* — `RoleSpec.BindingKey()`: the one
  definition of a role entry's uniqueness identity (`namespace:effectiveName`),
  consumed by both the webhook and the controller.
- **`api/v1alpha1/user_types.go`** — `spec.clusterRoles` gains
  `+listType=map` / `+listMapKey=existingClusterRole` (native uniqueness);
  both list fields gain `+kubebuilder:validation:MaxItems=100`; role/clusterRole
  name fields gain `MaxLength=253`. CRDs regenerated.
- **`config/crd/bases/auth.openkube.io_users.yaml`** + **`helm/kubeuser/templates/crd.yaml`**
  — regenerated/synced with the above.
- **`internal/controller/rbac/bindings.go`** — both reconcilers now detect a
  duplicate key and return a descriptive error (surfaced as `phase=Error`)
  instead of overwriting the map. Roles use `BindingKey()`.
- **`internal/webhook/user_webhook.go`** — `validateRoles` rejects duplicate
  `BindingKey()`s at admission. `validateClusterRoles` relies on the CRD
  `listType=map` for uniqueness (no code-level dedup).
- **`internal/controller/rbac/bindings_test.go`** *(new)* — table-driven unit
  tests for both reconcilers (exact dup, Role-vs-ClusterRole same name, distinct,
  order-independence).

## Verification

All run on `kind` (v1.34) with a freshly built controller image.

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test ./...` green
      (new `rbac` package tests included).
- [x] **Native clusterRoles enforcement** — on a cluster with **no webhook**,
      a User with duplicate `clusterRoles` is rejected by the apiserver schema:
      `spec.clusterRoles[1]: Duplicate value: {"existingClusterRole":"view"}`.
- [x] **Unbypassable** — with the validating webhook **deleted**, duplicate
      `clusterRoles` is *still* rejected (proof it's structural-schema, not
      webhook).
- [x] **Webhook roles enforcement** — duplicate `spec.roles` (Role `shared` +
      ClusterRole `shared` in `dev`) rejected:
      `admission webhook "vuser.auth.openkube.io" denied the request:
      duplicate role binding "dev:shared" in spec.roles`.
- [x] **Controller backstop** — with the webhook bypassed, a duplicate-roles
      User is admitted, then the controller sets `phase=Error`
      (`duplicate spec.roles entry "dev:shared" appears more than once`) and
      creates **0** RoleBindings — no silent drop.
- [x] **No regression** — a valid User (distinct roles + clusterRoles) reaches
      `Active` with the expected 2 RoleBindings + 2 ClusterRoleBindings.

## Risk

Low.

- No API shape change; this is validation tightening + a list-type change.
- **`listType=map` on `clusterRoles` changes server-side-apply semantics**
  from atomic (whole-list replace) to map (per-entry merge by key). For a
  uniqueness-keyed list this is the correct/idiomatic behavior and matches what
  GitOps tooling expects; flagged for anyone relying on atomic replacement.
- `MaxItems=100` is a deliberate bound; existing Users with >100 bindings
  (none expected in practice) would be rejected on next write.
- Failure mode is **fail-closed** (under-provisioning, never over-provisioning) —
  no privilege-escalation surface.
- A duplicate object created before this change persists in etcd until its next
  write; the controller backstop surfaces it as `Error` rather than dropping.

## Known limitation (follow-up)

The generated RoleBinding name `<user>-<role>-rb` encodes neither the binding
*kind* nor the namespace, so a `Role` and a `ClusterRole` of the same name in
the same namespace cannot both exist as distinct objects. This PR **rejects**
such input (the honest behavior) rather than fixing the naming scheme, which
would be a collision-proof rename with migration implications. Tracked as a
follow-up.

## How to reproduce

```bash
# native clusterRoles rejection (no webhook needed):
kubectl apply -f config/crd/bases/auth.openkube.io_users.yaml
cat <<EOF | kubectl apply -f -   # expect: Duplicate value
apiVersion: auth.openkube.io/v1alpha1
kind: User
metadata: { name: t }
spec: { auth: { type: x509 }, clusterRoles: [ { existingClusterRole: view }, { existingClusterRole: view } ] }
EOF

# roles rejection requires the controller+webhook deployed; see PR verification.
```
