### PR TITLE
refactor(certs): propagate kubeconfig build errors and drop base64 round-trip

### DIFF
--- a/internal/controller/certs/certs.go
+++ b/internal/controller/certs/certs.go
@@ -408,7 +408,7 @@ func persistKubeconfig(ctx context.Context, r client.Client, user *authv1alpha1.
 	cfgSecretName := fmt.Sprintf("%s-kubeconfig", username)
 
 	// Get cluster CA certificate
-	caDataB64, err := getClusterCABase64(ctx, r)
+	caData, err := getClusterCA(ctx, r)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster CA: %w", err)
 	}
@@ -420,14 +420,10 @@ func persistKubeconfig(ctx context.Context, r client.Client, user *authv1alpha1.
 	}
 
 	// Build kubeconfig
-	kcfg := buildCertKubeconfig(
-		apiServer,
-		caDataB64,
-		base64.StdEncoding.EncodeToString(certPEM),
-		base64.StdEncoding.EncodeToString(keyPEM),
-		username,
-		clusterName,
-	)
+	kcfg, err := buildCertKubeconfig(apiServer, caData, certPEM, keyPEM, username, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
 
 	// Create or update kubeconfig secret
 	cfgSecret := &corev1.Secret{
@@ -464,20 +460,26 @@ func csrFromKey(username string, keyPEM []byte) ([]byte, error) {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}), nil
 }
 
-func getClusterCABase64(ctx context.Context, r client.Client) (string, error) {
+// getClusterCA returns the cluster CA certificate as raw PEM bytes. It first
+// looks at the in-cluster service-account CA and falls back to the
+// kube-root-ca.crt ConfigMap for out-of-cluster runs (e.g. `make run`).
+func getClusterCA(ctx context.Context, r client.Client) ([]byte, error) {
 	if data, err := os.ReadFile(filepath.Clean(inClusterCAPath)); err == nil && len(data) > 0 {
-		return base64.StdEncoding.EncodeToString(data), nil
+		return data, nil
 	}
 	var cm corev1.ConfigMap
 	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: "kube-root-ca.crt"}, &cm); err == nil {
 		if crt, ok := cm.Data["ca.crt"]; ok {
-			return base64.StdEncoding.EncodeToString([]byte(crt)), nil
+			return []byte(crt), nil
 		}
 	}
-	return "", errors.New("CA not found")
+	return nil, errors.New("CA not found")
 }
 
-func buildCertKubeconfig(apiServer, caDataB64, certDataB64, keyDataB64, username, clusterName string) []byte {
+// buildCertKubeconfig serializes a kubeconfig for the given user via
+// clientcmd. All byte inputs are raw PEM; clientcmd handles the base64
+// encoding on YAML emission itself, so no pre-encoding is required.
+func buildCertKubeconfig(apiServer string, caData, certData, keyData []byte, username, clusterName string) ([]byte, error) {
 	if clusterName == "" {
 		clusterName = helpers.DefaultKubeconfigClusterName
 	}
@@ -488,13 +490,13 @@ func buildCertKubeconfig(apiServer, caDataB64, certDataB64, keyDataB64, username
 		Clusters: map[string]*clientcmdapi.Cluster{
 			clusterName: {
 				Server:                   apiServer,
-				CertificateAuthorityData: decodeBase64OrRaw(caDataB64),
+				CertificateAuthorityData: caData,
 			},
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
 			username: {
-				ClientCertificateData: decodeBase64OrRaw(certDataB64),
-				ClientKeyData:         decodeBase64OrRaw(keyDataB64),
+				ClientCertificateData: certData,
+				ClientKeyData:         keyData,
 			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
@@ -507,17 +509,9 @@ func buildCertKubeconfig(apiServer, caDataB64, certDataB64, keyDataB64, username
 		CurrentContext: contextName,
 	})
 	if err != nil {
-		return []byte{}
+		return nil, fmt.Errorf("failed to serialize kubeconfig for user %q: %w", username, err)
 	}
-	return kubeconfig
-}
-
-func decodeBase64OrRaw(value string) []byte {
-	decoded, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		return []byte(value)
-	}
-	return decoded
+	return kubeconfig, nil
 }
 
 // extractCertificateExpiryWithFormatDetection tries multiple formats to extract certificate expiry
@@ -689,9 +683,9 @@ func getRotationThreshold(certDuration time.Duration) time.Duration {
 	return certDuration / 4 // 25% of original duration
 }
 
-// GetClusterCABase64 gets the cluster CA certificate in base64 format (exported for renewal package)
-func GetClusterCABase64(ctx context.Context, r client.Client) (string, error) {
-	return getClusterCABase64(ctx, r)
+// GetClusterCA returns the cluster CA certificate as raw PEM bytes (exported for renewal package).
+func GetClusterCA(ctx context.Context, r client.Client) ([]byte, error) {
+	return getClusterCA(ctx, r)
 }
 
 // GetAPIServerURL gets the API server URL (exported for renewal package)
@@ -703,18 +697,15 @@ func GetAPIServerURL() string {
 	return apiServer
 }
 
-// BuildCertKubeconfig builds a kubeconfig with certificate authentication (exported for renewal package)
-func BuildCertKubeconfig(apiServer, caDataB64 string, signedCert, keyPEM []byte, username string) []byte {
-	return BuildCertKubeconfigWithClusterName(apiServer, caDataB64, signedCert, keyPEM, username, helpers.DefaultKubeconfigClusterName)
+// BuildCertKubeconfig builds a kubeconfig with certificate authentication
+// using the default cluster name (exported for renewal package).
+func BuildCertKubeconfig(apiServer string, caData, signedCert, keyPEM []byte, username string) ([]byte, error) {
+	return BuildCertKubeconfigWithClusterName(apiServer, caData, signedCert, keyPEM, username, helpers.DefaultKubeconfigClusterName)
 }
 
 // BuildCertKubeconfigWithClusterName builds a kubeconfig with a configurable cluster name.
-func BuildCertKubeconfigWithClusterName(apiServer, caDataB64 string, signedCert, keyPEM []byte, username, clusterName string) []byte {
-	return buildCertKubeconfig(apiServer, caDataB64,
-		base64.StdEncoding.EncodeToString(signedCert),
-		base64.StdEncoding.EncodeToString(keyPEM),
-		username,
-		clusterName)
+func BuildCertKubeconfigWithClusterName(apiServer string, caData, signedCert, keyPEM []byte, username, clusterName string) ([]byte, error) {
+	return buildCertKubeconfig(apiServer, caData, signedCert, keyPEM, username, clusterName)
 }
 
 // ExtractCertificateExpiryWithFormatDetection extracts certificate expiry (exported for renewal package)

--- a/internal/controller/certs/certs_test.go
+++ b/internal/controller/certs/certs_test.go
@@ -103,74 +103,58 @@ KoZIhvcNAQELBQADQQDDw3xWEKNUMA0GCSqGSIb3DQEBCwUAA0EAw8N8VhCjVDA=
 }
 
 func TestBuildCertKubeconfig(t *testing.T) {
+	// Raw PEM bytes — clientcmd.Write handles the base64 wrapping on YAML
+	// emit, so callers pass raw data straight through.
+	caData := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+	certData := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+	keyData := []byte("-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----")
+
 	tests := []struct {
 		name      string
 		apiServer string
-		caDataB64 string
-		certB64   string
-		keyB64    string
 		username  string
-		wantEmpty bool
 	}{
 		{
 			name:      "valid kubeconfig generation",
 			apiServer: "https://kubernetes.default.svc",
-			caDataB64: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t", // Base64 for "-----BEGIN CERTIFICATE-----"
-			certB64:   "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-			keyB64:    "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t", // Base64 for "-----BEGIN PRIVATE KEY-----"
 			username:  "alice",
-			wantEmpty: false,
 		},
 		{
 			name:      "empty username",
 			apiServer: "https://kubernetes.default.svc",
-			caDataB64: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-			certB64:   "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-			keyB64:    "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t",
 			username:  "",
-			wantEmpty: false, // Should still generate kubeconfig
 		},
 		{
 			name:      "empty API server",
 			apiServer: "",
-			caDataB64: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-			certB64:   "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-			keyB64:    "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t",
 			username:  "alice",
-			wantEmpty: false, // Should still generate kubeconfig
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := BuildCertKubeconfig(tt.apiServer, tt.caDataB64, []byte(tt.certB64), []byte(tt.keyB64), tt.username)
-
-			if tt.wantEmpty && len(got) > 0 {
-				t.Errorf("BuildCertKubeconfig() expected empty result, got %d bytes", len(got))
+			got, err := BuildCertKubeconfig(tt.apiServer, caData, certData, keyData, tt.username)
+			if err != nil {
+				t.Fatalf("BuildCertKubeconfig() unexpected error: %v", err)
+			}
+			if len(got) == 0 {
+				t.Fatalf("BuildCertKubeconfig() returned empty bytes")
 			}
 
-			if !tt.wantEmpty && len(got) == 0 {
-				t.Errorf("BuildCertKubeconfig() expected non-empty result, got empty")
+			kubeconfigStr := string(got)
+			expectedStrings := []string{
+				"apiVersion: v1",
+				"kind: Config",
+				"clusters:",
+				"users:",
+				"contexts:",
+				"current-context:",
+				"  name: cluster",
+				"    cluster: cluster",
 			}
-
-			// Basic validation that it contains expected kubeconfig structure
-			if !tt.wantEmpty {
-				kubeconfigStr := string(got)
-				expectedStrings := []string{
-					"apiVersion: v1",
-					"kind: Config",
-					"clusters:",
-					"users:",
-					"contexts:",
-					"current-context:",
-					"  name: cluster",
-					"    cluster: cluster",
-				}
-
-				for _, expected := range expectedStrings {
-					if !contains(kubeconfigStr, expected) {
-						t.Errorf("BuildCertKubeconfig() missing expected string: %s", expected)
-					}
+			for _, expected := range expectedStrings {
+				if !contains(kubeconfigStr, expected) {
+					t.Errorf("BuildCertKubeconfig() missing expected string: %s", expected)
 				}
 			}
 		})
@@ -178,14 +162,22 @@ func TestBuildCertKubeconfig(t *testing.T) {
 }
 
 func TestBuildCertKubeconfigWithClusterName(t *testing.T) {
-	got := string(BuildCertKubeconfigWithClusterName(
+	caData := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+	certData := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+	keyData := []byte("-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----")
+
+	rawKubeconfig, err := BuildCertKubeconfigWithClusterName(
 		"https://kubernetes.default.svc",
-		"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-		[]byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t"),
-		[]byte("LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t"),
+		caData,
+		certData,
+		keyData,
 		"alice",
 		"production",
-	))
+	)
+	if err != nil {
+		t.Fatalf("BuildCertKubeconfigWithClusterName() unexpected error: %v", err)
+	}
+	got := string(rawKubeconfig)
 
 	expectedStrings := []string{
 		"  name: production",

--- a/internal/controller/renewal/rotation.go
+++ b/internal/controller/renewal/rotation.go
@@ -643,15 +643,19 @@ func (rm *RotationManager) atomicSecretUpdate(ctx context.Context, user *authv1a
 	userNamespace := helpers.GetKubeUserNamespace()
 
 	// Get cluster CA and API server info
-	caDataB64, err := rm.getClusterCABase64(ctx)
+	caData, err := rm.getClusterCA(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster CA: %w", err)
 	}
 
 	apiServer := rm.getAPIServerURL()
 
-	// Build new kubeconfig
-	newKubeconfig := rm.buildKubeconfig(apiServer, caDataB64, signedCert, newKeyPEM, username)
+	// Build new kubeconfig before touching either target secret; if serialization
+	// fails we abort here instead of half-writing the shadow-flip.
+	newKubeconfig, err := rm.buildKubeconfig(apiServer, caData, signedCert, newKeyPEM, username)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
 
 	// Backup existing secrets for rollback
 	keySecretName := fmt.Sprintf("%s-key", username)
@@ -860,9 +864,8 @@ func (rm *RotationManager) GetRotationRequeueDelay(certDuration time.Duration) t
 	return 2 * time.Minute
 }
 
-func (rm *RotationManager) getClusterCABase64(ctx context.Context) (string, error) {
-	// Use the existing implementation from certs package
-	return certs.GetClusterCABase64(ctx, rm.client)
+func (rm *RotationManager) getClusterCA(ctx context.Context) ([]byte, error) {
+	return certs.GetClusterCA(ctx, rm.client)
 }
 
 func (rm *RotationManager) getAPIServerURL() string {
@@ -870,9 +873,8 @@ func (rm *RotationManager) getAPIServerURL() string {
 	return certs.GetAPIServerURL()
 }
 
-func (rm *RotationManager) buildKubeconfig(apiServer, caDataB64 string, signedCert, keyPEM []byte, username string) []byte {
-	// Use the existing implementation from certs package
-	return certs.BuildCertKubeconfigWithClusterName(apiServer, caDataB64, signedCert, keyPEM, username, rm.clusterName)
+func (rm *RotationManager) buildKubeconfig(apiServer string, caData, signedCert, keyPEM []byte, username string) ([]byte, error) {
+	return certs.BuildCertKubeconfigWithClusterName(apiServer, caData, signedCert, keyPEM, username, rm.clusterName)
 }
 
 func (rm *RotationManager) extractCertificateExpiry(certData []byte) (time.Time, error) {

--- a/internal/controller/renewal/rotation_test.go
+++ b/internal/controller/renewal/rotation_test.go
@@ -56,13 +56,17 @@ func TestRotationManager_generateUniqueCSRName(t *testing.T) {
 func TestRotationManagerBuildKubeconfigUsesConfiguredClusterName(t *testing.T) {
 	rm := NewRotationManager(nil, nil, "", "production", nil)
 
-	got := string(rm.buildKubeconfig(
+	rawKubeconfig, err := rm.buildKubeconfig(
 		"https://kubernetes.default.svc",
-		"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-		[]byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t"),
-		[]byte("LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t"),
+		[]byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"),
+		[]byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"),
+		[]byte("-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----"),
 		"alice",
-	))
+	)
+	if err != nil {
+		t.Fatalf("buildKubeconfig() unexpected error: %v", err)
+	}
+	got := string(rawKubeconfig)
 
 	expectedStrings := []string{
 		"  name: production",


### PR DESCRIPTION
## Summary

Follow-up to #90. Two small tidyups in `internal/controller/certs`:

- **Propagate errors from `buildCertKubeconfig`.** Previously the builder returned `[]byte{}` on `clientcmd.Write` failure, which would have silently written an empty kubeconfig into the user's Secret with no diagnostic in logs or status. Now returns `([]byte, error)` and callers wrap as `failed to build kubeconfig: %w`.
- **Drop the base64 round-trip.** The old string-template kubeconfig builder needed base64-encoded inputs; `clientcmd.Write` takes raw bytes in the `*Data` fields and handles base64 wrapping itself on YAML emission. The current path was `raw → base64.EncodeToString → decodeBase64OrRaw → raw`, mediated by an accept-anything shim. Pass raw bytes end-to-end, delete the shim.

## Changes

- `buildCertKubeconfig` takes raw `[]byte` for CA/cert/key and returns `([]byte, error)`.
- `BuildCertKubeconfig` / `BuildCertKubeconfigWithClusterName` exports updated to match; renewal package caller updated.
- `getClusterCABase64` → `getClusterCA` returning raw `[]byte`; same for the exported `GetClusterCA` wrapper.
- `decodeBase64OrRaw` deleted (dead).
- `persistKubeconfig` and `RotationManager.atomicSecretUpdate` handle the new error return; `atomicSecretUpdate` builds the kubeconfig before touching either target Secret so a serialization failure aborts *before* the shadow-flip.
- Tests pass raw PEM bytes and assert on `(bytes, err)`.

No behavior change on the happy path — identical inputs still produce identical kubeconfig YAML.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/...`
- [ ] CI (lint + tests + e2e) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)