### PR TITLE
fix(controller): end the reconcile pass after adding the finalizer to prevent stale-object status conflicts

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -57,7 +57,15 @@ Counter tracking total reconciliation attempts.
 
 Labels:
 - `controller`: Controller name (e.g., `user`)
-- `result`: Reconciliation result (`success`, `error`, `requeued`, `deleted`, `not_found`)
+- `result`: Reconciliation result (`success`, `error`, `conflict`, `requeued`, `finalizer_added`, `deleted`, `not_found`)
+
+Notable result values:
+- `finalizer_added`: a first reconcile pass that persisted the finalizer and
+  ended; the watch event from that write triggers the business-logic pass.
+- `conflict`: a status update lost an optimistic-concurrency race with a
+  concurrent writer and was discarded; the reconcile requeues in 5 seconds
+  and recomputes. Sustained non-zero rates indicate another writer fighting
+  over the same objects. These are not counted as `error`.
 
 #### `kubeuser_reconcile_duration_seconds`
 Histogram tracking reconciliation loop duration.
@@ -73,7 +81,7 @@ Gauge tracking the number of items waiting in the controller work queue (i.e., r
 Labels:
 - `name`: Controller queue name (e.g., `user`)
 
-> **Note:** `kubeuser_workqueue_depth` was removed. Use `workqueue_depth{name="user"}` as the practical replacement — it tracks reconciliation backlog, which is the actionable signal for SRE monitoring and alerting. `controller_runtime_active_workers{controller="user"}` is also exposed automatically but is bounded by `MaxConcurrentReconciles` (default `1`), so it's only meaningful when concurrency is tuned up.
+> **Note:** `kubeuser_workqueue_depth` was removed. Use `workqueue_depth{name="user"}` as the practical replacement: it tracks reconciliation backlog, which is the actionable signal for SRE monitoring and alerting. `controller_runtime_active_workers{controller="user"}` is also exposed automatically but is bounded by `MaxConcurrentReconciles` (default `1`), so it's only meaningful when concurrency is tuned up.
 
 ### Thundering Herd Protection
 

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -61,6 +61,17 @@ type UserReconciler struct {
 // Admission resources
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;patch
 
+// Result label values recorded on the kubeuser_reconciliations_total metric.
+const (
+	reconcileResultNotFound       = "not_found"
+	reconcileResultDeleted        = "deleted"
+	reconcileResultError          = "error"
+	reconcileResultFinalizerAdded = "finalizer_added"
+	reconcileResultConflict       = "conflict"
+	reconcileResultRequeued       = "requeued"
+	reconcileResultSuccess        = "success"
+)
+
 // Reconcile orchestrates the user reconciliation process as a pure orchestrator.
 // It implements an idempotent update pattern to minimize etcd writes and prevent infinite loops.
 func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -93,7 +104,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	var user authv1alpha1.User
 	if err := r.Get(ctx, req.NamespacedName, &user); err != nil {
 		logger.Info("User not found, ignoring", "user", req.Name, "error", err)
-		reconcileResult = "not_found"
+		reconcileResult = reconcileResultNotFound
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -110,14 +121,32 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// 2. Handle Deletion
 	if !user.DeletionTimestamp.IsZero() {
-		reconcileResult = "deleted"
+		reconcileResult = reconcileResultDeleted
 		return ctrl.Result{}, r.handleDeletion(ctx, &user)
 	}
 
-	// Ensure finalizer
-	if err := r.ensureFinalizer(ctx, &user); err != nil {
-		reconcileResult = "error"
+	// Ensure finalizer. When this call performs an API update, the in-memory
+	// object must not be reused for further writes in this pass (issue #58):
+	// any concurrent mutation landing while business logic runs would make the
+	// final Status().Update fail with a conflict, discarding its output. End
+	// the pass instead. The successful update produces a watch event that is
+	// handed to this controller only after the informer cache has absorbed the
+	// update, so the pass that event triggers starts from a fresh Get. A pass
+	// triggered earlier by some other queued event can still read the older
+	// cache; it then re-attempts the add, conflicts harmlessly on the write,
+	// and retries with backoff, never reaching business logic with a stale
+	// object. An explicit Requeue here would make that stale re-entry the
+	// common case instead of the rare exception, which is why none is set.
+	finalizerAdded, err := r.ensureFinalizer(ctx, &user)
+	if err != nil {
+		reconcileResult = reconcileResultError
 		return ctrl.Result{}, err
+	}
+	if finalizerAdded {
+		logger.Info("=== END RECONCILE (FINALIZER ADDED) ===",
+			"reason", "watch event from the finalizer update triggers the next pass on a fresh object")
+		reconcileResult = reconcileResultFinalizerAdded
+		return ctrl.Result{}, nil
 	}
 
 	// 3. Run Business Logic
@@ -141,29 +170,49 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// 5. ONE Status Update call (if needed)
 	if statusChanged {
 		if updateErr := r.Status().Update(ctx, &user); updateErr != nil {
+			// On an optimistic-concurrency conflict the computed status is
+			// discarded and recomputed on the next pass. Record what was lost
+			// so the discard is visible in logs (issue #58), then requeue in
+			// 5 seconds WITHOUT returning the error: conflicts are expected
+			// contention, and returning a non-nil error would make
+			// controller-runtime ignore the RequeueAfter, retry on its
+			// millisecond-scale rate-limiter backoff instead, and double-log
+			// the conflict at error level.
+			if apierrors.IsConflict(updateErr) {
+				logger.Info("Status update conflicted with a concurrent write, discarding computed status and requeueing",
+					"discardedPhase", user.Status.Phase,
+					"discardedRotationStep", user.Status.RotationStep,
+					"discardedMessage", user.Status.Message)
+				reconcileResult = reconcileResultConflict
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			}
 			logger.Error(updateErr, "Failed to update user status")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, updateErr
+			reconcileResult = reconcileResultError
+			// Return the error alone: controller-runtime ignores any Result
+			// when the error is non-nil and requeues with backoff, so a
+			// RequeueAfter here would be dead code.
+			return ctrl.Result{}, updateErr
 		}
 		logger.Info("Status updated successfully", "phase", user.Status.Phase, "rotationStep", user.Status.RotationStep)
 	}
 
 	// Handle any error that occurred during business logic after status update
 	if err != nil {
-		reconcileResult = "error"
+		reconcileResult = reconcileResultError
 		return r.handleError(ctx, &user, err)
 	}
 
 	// 6. Return pending result if one was captured (e.g., immediate requeue for Shadow Secret creation)
 	if pendingResult != nil {
 		logger.Info("=== END RECONCILE (PENDING REQUEUE) ===", "requeueAfter", pendingResult.RequeueAfter)
-		reconcileResult = "requeued"
+		reconcileResult = reconcileResultRequeued
 		return *pendingResult, nil
 	}
 
 	// 7. Calculate Requeue
 	requeueResult := r.calculateRequeue(ctx, &user)
 	logger.Info("=== END RECONCILE ===", "requeueAfter", requeueResult.RequeueAfter, "statusCommitted", statusChanged)
-	reconcileResult = "success"
+	reconcileResult = reconcileResultSuccess
 
 	// Update user sync status metric
 	if r.Metrics != nil {
@@ -301,19 +350,24 @@ func (r *UserReconciler) handleDeletion(ctx context.Context, user *authv1alpha1.
 }
 
 // ensureFinalizer adds the user finalizer if not present.
-func (r *UserReconciler) ensureFinalizer(ctx context.Context, user *authv1alpha1.User) error {
+// It returns true when the finalizer was added by this call, meaning an API
+// update was performed and the caller must end the current reconcile pass
+// instead of reusing the object for further writes (issue #58).
+func (r *UserReconciler) ensureFinalizer(ctx context.Context, user *authv1alpha1.User) (bool, error) {
 	logger := logf.FromContext(ctx)
 
-	if !helpers.ContainsString(user.Finalizers, authv1alpha1.UserFinalizer) {
-		logger.Info("Adding finalizer", "finalizer", authv1alpha1.UserFinalizer)
-		user.Finalizers = append(user.Finalizers, authv1alpha1.UserFinalizer)
-		if err := r.Update(ctx, user); err != nil {
-			logger.Error(err, "Failed to add finalizer")
-			return err
-		}
-		logger.Info("Successfully added finalizer")
+	if helpers.ContainsString(user.Finalizers, authv1alpha1.UserFinalizer) {
+		return false, nil
 	}
-	return nil
+
+	logger.Info("Adding finalizer", "finalizer", authv1alpha1.UserFinalizer)
+	user.Finalizers = append(user.Finalizers, authv1alpha1.UserFinalizer)
+	if err := r.Update(ctx, user); err != nil {
+		logger.Error(err, "Failed to add finalizer")
+		return false, err
+	}
+	logger.Info("Successfully added finalizer")
+	return true, nil
 }
 
 // reconcileRBAC handles both RoleBindings and ClusterRoleBindings reconciliation.

--- a/internal/controller/user_controller_finalizer_test.go
+++ b/internal/controller/user_controller_finalizer_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	"github.com/openkube-hub/KubeUser/internal/controller/auth"
+)
+
+// raceInjectingClient wraps a client.Client and, exactly once, runs a hook
+// right after a successful Update of a User object. It reproduces the issue
+// #58 race deterministically: a concurrent writer landing immediately after
+// the reconciler's finalizer write. It also counts Update calls so tests can
+// assert a code path performed no API write at all.
+type raceInjectingClient struct {
+	client.Client
+	afterUserUpdate func()
+	fired           bool
+	updateCalls     int
+}
+
+func (c *raceInjectingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updateCalls++
+	err := c.Client.Update(ctx, obj, opts...)
+	if err == nil && !c.fired && c.afterUserUpdate != nil {
+		if _, ok := obj.(*authv1alpha1.User); ok {
+			c.fired = true
+			c.afterUserUpdate()
+		}
+	}
+	return err
+}
+
+// statusRaceClient wraps a client.Client and, exactly once, runs a hook right
+// BEFORE a status subresource update, so the update is guaranteed to hit an
+// optimistic-concurrency conflict.
+type statusRaceClient struct {
+	client.Client
+	beforeStatusUpdate func()
+	fired              bool
+}
+
+func (c *statusRaceClient) Status() client.SubResourceWriter {
+	return &racingStatusWriter{SubResourceWriter: c.Client.Status(), parent: c}
+}
+
+type racingStatusWriter struct {
+	client.SubResourceWriter
+	parent *statusRaceClient
+}
+
+func (w *racingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if !w.parent.fired && w.parent.beforeStatusUpdate != nil {
+		w.parent.fired = true
+		w.parent.beforeStatusUpdate()
+	}
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+// Regression tests for issue #58: after ensureFinalizer performed an API
+// update, the same in-memory object was passed on to business logic and to
+// the final Status().Update. A concurrent mutation landing in that window
+// made the status update fail with a conflict, silently discarding the
+// business logic output. The fix ends the reconcile pass when the finalizer
+// was just added, so every write sequence starts from a fresh Get, and
+// conflicts on the remaining window are logged and requeued without an error.
+var _ = Describe("User finalizer handling (issue #58)", func() {
+	ctx := context.Background()
+
+	newUser := func(name string) (*authv1alpha1.User, types.NamespacedName) {
+		key := types.NamespacedName{Name: name, Namespace: "default"}
+		u := &authv1alpha1.User{
+			ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+			Spec: authv1alpha1.UserSpec{
+				Auth: &authv1alpha1.AuthSpec{
+					Type: &[]string{auth.AuthTypeX509}[0],
+					TTL:  "24h",
+				},
+			},
+		}
+		return u, key
+	}
+
+	cleanupUser := func(key types.NamespacedName) {
+		u := &authv1alpha1.User{}
+		if err := k8sClient.Get(ctx, key, u); err == nil {
+			u.Finalizers = nil
+			_ = k8sClient.Update(ctx, u)
+			_ = k8sClient.Delete(ctx, u)
+		}
+	}
+
+	// mutateOutOfBand simulates a concurrent writer (kubectl label, GitOps
+	// sync) by updating a fresh copy of the User through a separate client
+	// path, bumping the server-side resourceVersion.
+	mutateOutOfBand := func(key types.NamespacedName, label string) {
+		var other authv1alpha1.User
+		Expect(k8sClient.Get(ctx, key, &other)).To(Succeed())
+		if other.Labels == nil {
+			other.Labels = map[string]string{}
+		}
+		other.Labels[label] = "true"
+		Expect(k8sClient.Update(ctx, &other)).To(Succeed())
+	}
+
+	It("reports whether the finalizer write was performed, without extra API writes", func() {
+		u, key := newUser("issue58-ensure")
+		Expect(k8sClient.Create(ctx, u)).To(Succeed())
+		DeferCleanup(func() { cleanupUser(key) })
+
+		counting := &raceInjectingClient{Client: k8sClient}
+		r := &UserReconciler{Client: counting, Scheme: k8sClient.Scheme()}
+
+		var user authv1alpha1.User
+		Expect(k8sClient.Get(ctx, key, &user)).To(Succeed())
+
+		By("first call performs exactly one update and reports it")
+		added, err := r.ensureFinalizer(ctx, &user)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(added).To(BeTrue())
+		Expect(counting.updateCalls).To(Equal(1))
+		Expect(user.Finalizers).To(ContainElement(authv1alpha1.UserFinalizer))
+
+		By("second call is a no-op and performs zero API writes")
+		added, err = r.ensureFinalizer(ctx, &user)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(added).To(BeFalse())
+		Expect(counting.updateCalls).To(Equal(1), "no Update call may be issued when the finalizer is already present")
+	})
+
+	It("ends the first reconcile pass after adding the finalizer, without writing status", func() {
+		u, key := newUser("issue58-first-pass")
+		Expect(k8sClient.Create(ctx, u)).To(Succeed())
+		DeferCleanup(func() { cleanupUser(key) })
+
+		r := &UserReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+		By("first pass persists the finalizer and returns an empty result")
+		res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.IsZero()).To(BeTrue(), "the watch event from the finalizer update drives the next pass")
+
+		var persisted authv1alpha1.User
+		Expect(k8sClient.Get(ctx, key, &persisted)).To(Succeed())
+		Expect(persisted.Finalizers).To(ContainElement(authv1alpha1.UserFinalizer))
+		Expect(persisted.Status.Phase).To(BeEmpty(), "no status write may share a pass with the finalizer write")
+
+		By("second pass persists the status computed by business logic")
+		// In envtest the business logic fails fast (the kubeuser namespace
+		// does not exist), so the persisted phase is Error. What this spec
+		// pins is the write choreography: pass one persisted nothing to
+		// status, pass two did.
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, key, &persisted)).To(Succeed())
+		Expect(persisted.Status.Phase).NotTo(BeEmpty())
+		Expect(persisted.Status.Message).NotTo(BeEmpty())
+	})
+
+	It("does not lose status output to a concurrent mutation landing right after the finalizer write", func() {
+		u, key := newUser("issue58-regression")
+		Expect(k8sClient.Create(ctx, u)).To(Succeed())
+		DeferCleanup(func() { cleanupUser(key) })
+
+		// The wrapper injects the concurrent mutation at the exact point the
+		// issue describes: immediately after the reconciler's own finalizer
+		// Update succeeds, before the pass can do anything else. On the
+		// pre-fix code this pass continued into business logic with the now
+		// stale object and its Status().Update returned 409, surfacing as a
+		// reconcile error. With the fix the pass ends before any further
+		// write, so the mutation is harmless.
+		racing := &raceInjectingClient{
+			Client:          k8sClient,
+			afterUserUpdate: func() { mutateOutOfBand(key, "issue58-concurrent-writer") },
+		}
+		r := &UserReconciler{Client: racing, Scheme: k8sClient.Scheme()}
+
+		By("first pass: finalizer write immediately followed by a concurrent mutation")
+		res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred(), "pre-fix code returned the 409 from the stale status update here")
+		Expect(res.IsZero()).To(BeTrue())
+		Expect(racing.fired).To(BeTrue(), "the concurrent mutation must have been injected")
+
+		var persisted authv1alpha1.User
+		Expect(k8sClient.Get(ctx, key, &persisted)).To(Succeed())
+		Expect(persisted.Finalizers).To(ContainElement(authv1alpha1.UserFinalizer))
+		Expect(persisted.Status.Phase).To(BeEmpty())
+
+		By("second pass starts from a fresh Get and persists status despite the mutation")
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, key, &persisted)).To(Succeed())
+		Expect(persisted.Status.Phase).NotTo(BeEmpty())
+		Expect(persisted.Labels).To(HaveKey("issue58-concurrent-writer"), "the concurrent write must survive untouched")
+	})
+
+	It("requeues a conflicted status update in 5 seconds without an error, discarding and recomputing", func() {
+		u, key := newUser("issue58-conflict")
+		Expect(k8sClient.Create(ctx, u)).To(Succeed())
+		DeferCleanup(func() { cleanupUser(key) })
+
+		plain := &UserReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+		By("first pass with a plain client persists the finalizer")
+		_, err := plain.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("second pass hits a guaranteed conflict on its status update")
+		racing := &statusRaceClient{
+			Client:             k8sClient,
+			beforeStatusUpdate: func() { mutateOutOfBand(key, "issue58-status-race") },
+		}
+		r := &UserReconciler{Client: racing, Scheme: k8sClient.Scheme()}
+		res, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred(), "a status conflict is expected contention, not a reconcile error")
+		Expect(res.RequeueAfter.Seconds()).To(BeNumerically("==", 5), "conflicts requeue on a real 5 second cadence")
+		Expect(racing.fired).To(BeTrue())
+
+		var persisted authv1alpha1.User
+		Expect(k8sClient.Get(ctx, key, &persisted)).To(Succeed())
+		Expect(persisted.Status.Phase).To(BeEmpty(), "the conflicted status write must be discarded, not retried blindly")
+
+		By("the requeued pass recomputes and persists the status")
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, key, &persisted)).To(Succeed())
+		Expect(persisted.Status.Phase).NotTo(BeEmpty())
+	})
+})

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -79,10 +79,19 @@ var _ = Describe("User Controller", func() {
 				Scheme: k8sClient.Scheme(),
 			}
 
+			// The first pass persists the finalizer and ends (issue #58
+			// fresh-object pattern); the second pass runs the business logic.
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, user)).To(Succeed())
+			Expect(user.Finalizers).To(ContainElement(authv1alpha1.UserFinalizer))
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})


### PR DESCRIPTION


## Summary

`Reconcile` threaded one in-memory `User` object through three API writes in a
single pass: the finalizer update in `ensureFinalizer`, the business logic
(RBAC fan-out, CSR approval, secret rotation, up to a 2 minute budget), and the
final `Status().Update`. Any concurrent mutation landing between the finalizer
write and the status write (a `kubectl label`, a GitOps sync, another
controller touching metadata) bumped the object's `resourceVersion`, so the
status update failed with an optimistic-concurrency conflict. The computed
status (phase, message, expiry, `rotationStep` checkpoint) was silently
discarded with no record of what was lost, and the controller retried on
controller-runtime's rate-limiter backoff. (The code returned
`RequeueAfter: 5s` alongside the error, but controller-runtime ignores the
Result whenever the error is non-nil, so the 5 second cadence never actually
existed.) The cluster-side effects had already happened at that point, which
is exactly the status desync described in the issue.

Closes #58

## Reproduction

Confirmed against a real apiserver (envtest, k8s 1.36.2) before writing the
fix, driving the actual code paths:

1. `Get` User (rv 855)
2. `ensureFinalizer` update (in-memory object now rv 856)
3. concurrent client adds a label (server now rv 857)
4. business logic output written to the in-memory object's status
5. `Status().Update` returns **409 Conflict**; a fresh `Get` proves the
   phase and message never reached the server

## Design (deviation from the issue text, with reasoning)

The issue prescribed re-fetching the `User` after `ensureFinalizer`. A literal
`r.Get` re-fetch has a trap: the controller-runtime client reads from the
informer cache, which may not have absorbed the finalizer write yet. The
re-fetch can return an object **older** than the one already in memory, which
guarantees the very conflict this issue is about, and hands business logic an
object that appears to lack the finalizer. Avoiding that would require a
conditional live `APIReader` read on the finalizer-adding pass, adding a
second read path for the same freshness the watch event already provides.

Instead this PR uses the idiomatic controller-runtime pattern that satisfies
the same intent with less machinery: **when the finalizer was just added, end
the pass**.

- `ensureFinalizer` now reports whether it performed the API update.
- When it did, `Reconcile` returns an empty result immediately. The successful
  update produces a watch event that is handed to the controller only after
  the informer cache has absorbed the update, so the pass that event triggers
  starts from a fresh `Get`. A pass triggered earlier by some other queued
  event can still read the older cache; it then re-attempts the add, conflicts
  harmlessly on the write, and retries with backoff. It can never reach
  business logic with a stale object. This is also why the code returns
  `ctrl.Result{}` and not an explicit requeue: an immediate requeue would make
  the stale re-entry the common case instead of the rare exception.
- Net effect: a reconcile pass never mixes a metadata write and a status write,
  so the stale-object window around the finalizer update is gone, not narrowed.

Two companions to the core fix, both born from the issue's complaint that the
conflict left "no record of what was lost":

- A status update that loses the optimistic-concurrency race now logs the
  discarded phase, rotation step, and message at Info level, and returns
  `RequeueAfter: 5s` with a **nil error**. Conflicts are expected contention,
  not failures; returning the error (the old behavior) made controller-runtime
  ignore the requested requeue, retry on millisecond-scale backoff, and log
  every conflict twice at error level. The 5 second cadence promised by the
  old code is now real. Non-conflict status failures still return the error,
  now without the dead `RequeueAfter` that controller-runtime warns about and
  ignores.
- The `kubeuser_reconciliations_total` metric gains two result values:
  `finalizer_added` makes first-pass reconciles directly observable, and
  `conflict` counts discarded status updates. The status-failure path
  previously recorded an **empty** result label because it never set the
  tracking variable; that gap is closed. All result label values are now
  named constants, and `docs/metrics.md` documents the full set.

Alerting note: `KubeUserReconciliationErrors` matches `result="error"`.
Before this change, no status-update failure of any kind fed that alert (they
all recorded the empty label). After it, genuine status-update errors feed the
alert for the first time, and conflicts are deliberately excluded under their
own `conflict` value. A conflict-rate alert is left as a follow-up.

Cost of the core fix: one extra (cheap) reconcile pass on user creation only.
The initial `Pending` status is persisted one pass later; the watch event
fires immediately, so the user-visible delay is milliseconds.

## Out of scope (follow-up)

A conflict can still occur when a concurrent mutation lands **during**
business logic, since the status update reuses the object fetched at the top
of the pass. That window is inherent to the read-compute-write cycle. It is
now observable (log plus metric) and self-heals on a true 5 second requeue.
Closing it entirely needs a `retry.RetryOnConflict` re-fetch-and-reapply
around the status update; drafted as a follow-up issue together with the
optional conflict-rate alert.

## Changes

- **`internal/controller/user_controller.go`**
  - `ensureFinalizer` returns `(bool, error)`; true means an API update was
    performed and the caller must not reuse the object in this pass.
  - `Reconcile` ends the pass with `ctrl.Result{}` when the finalizer was just
    added (metric result `finalizer_added`), with a comment documenting the
    watch-event and cache-ordering reasoning.
  - Conflicted status updates: Info log with the discarded fields, metric
    result `conflict`, real 5 second requeue with nil error. Other status
    update failures: error return without the previously ignored
    `RequeueAfter`.
  - Reconciliation metric result values are named constants.
- **`internal/controller/user_controller_finalizer_test.go`** *(new)*
  envtest regression tests against a real apiserver, using race-injecting
  client wrappers that fire a concurrent mutation at the exact points the
  issue describes:
  - `ensureFinalizer` reports the write on first call; the second call
    performs zero Update calls (asserted by counting, not inferred from
    resourceVersion).
  - the first reconcile pass persists the finalizer, returns an empty result,
    and writes no status in the same pass; the second pass persists status.
  - the issue #58 race end to end: a mutation injected immediately after the
    finalizer write no longer surfaces a conflict or loses status output.
  - a guaranteed status-update conflict returns nil error with a 5 second
    requeue, discards the write, and the next pass persists.
- **`internal/controller/user_controller_test.go`** scaffolded spec updated
  to reconcile twice (the first pass now intentionally stops after the
  finalizer write) and to assert the finalizer.
- **`docs/metrics.md`** result label enumeration updated with
  `finalizer_added` and `conflict`, with guidance on reading them.

## Verification

Static and unit layers:

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean; `golangci-lint` 0 issues.
- [x] Full `go test` green; controller suite run 3 consecutive times with no
      flakes (envtest, real apiserver, k8s 1.36.2 control plane).
- [x] **Mutation test**: with the early return disabled to recreate pre-fix
      behavior, 3 of the 4 new specs fail (the fourth pins only the
      `ensureFinalizer` contract, which is orthogonal to the early return).
      The suite demonstrably pins the fix.
- [x] The original bug was reproduced on pre-fix code with the same envtest
      sequence before the fix was written: 409 Conflict, status lost.

Live on `kind` (v1.34), cluster built by `hack/setup-cluster.sh`, freshly
built controller image (2 replicas, leader election on). Metric and log
counts below were collected after a controller rollout, so they cover the
stress run only:

- [x] **Fix active**: smoke-test user shows exactly one
      `=== END RECONCILE (FINALIZER ADDED) ===` pass, then business logic on
      the next pass; reaches `Active`; generated kubeconfig works against the
      cluster.
- [x] **Concurrent-writer stress**: 10 users created while a writer applied
      **569 label updates in 30 seconds** across them. All 10 reached
      `Active` with finalizer and kubeconfig secret present, and each had
      **exactly one** `finalizer_added` pass: the early return does not loop
      or re-add.
- [x] **Conflict handling**: the 6 conflicts that occurred in the residual
      mid-business-logic window were each logged at Info with
      `discardedPhase`, `discardedRotationStep`, `discardedMessage`, and the
      controller emitted **zero error-level log lines** during the entire
      stress run (previously every conflict produced a controller-runtime
      `Reconciler error` plus an ignored-result warning).
- [x] **Metrics**: `kubeuser_reconciliations_total` result labels
      `{success: 524, conflict: 6, finalizer_added: 10, requeued: 14}`;
      the accidental empty result label no longer occurs.
- [x] **Deletion path untouched**: all 10 stress users deleted cleanly,
      finalizers removed after cleanup, zero leftover secrets, unrelated
      user unaffected.

## Risk

Low.

- No API or CRD change; single-controller behavior change on the first
  reconcile of a User, plus the conflict-return change described above.
- Deletion, renewal, and error paths are untouched.
- The early return relies on controller-runtime's event-after-cache-update
  ordering, the same mechanism every reconcile trigger already depends on.
  If the watch stream drops in the window, the informer's relist on reconnect
  re-delivers the object's state and re-enqueues it. The hard backstop is the
  periodic resync, which is controller-runtime's default of 10 hours in this
  deployment (no custom `SyncPeriod` is configured); acceptable because the
  finalizer is already persisted at that point and the exposure is delayed
  status, not lost cleanup. Configuring a shorter `SyncPeriod` is possible if
  that bound ever matters.
- Behavior change to be aware of: status-update conflicts no longer surface
  as reconcile errors to controller-runtime, so they leave its
  `controller_runtime_reconcile_errors_total` metric and error logs, and
  appear under `kubeuser_reconciliations_total{result="conflict"}` and an
  Info log instead. Genuine status-update errors now feed
  `result="error"` (and the `KubeUserReconciliationErrors` alert) for the
  first time; previously they were recorded under an empty label nothing
  consumed.
