### PR TITLE
fix(cleanup): propagate deletion errors so finalizer removal blocks on failure

### DIFF
--- a/internal/controller/cleanup/finalizers.go
+++ b/internal/controller/cleanup/finalizers.go
@@ -8,6 +8,7 @@ package cleanup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,9 +22,11 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// CleanupUserResources deletes resources owned by the user. Best-effort:
-// per-resource failures are logged but never block finalizer removal.
-func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alpha1.User) {
+// CleanupUserResources deletes resources owned by the user. All per-resource
+// failures are logged AND aggregated into the returned error so the caller can
+// block finalizer removal — otherwise a partial cleanup would silently orphan
+// Secrets, CSRs, or RoleBindings the moment the finalizer is stripped.
+func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alpha1.User) error {
 	// Finalizer cleanup must complete promptly to unblock the deletion path.
 	// The caller's context may already be bounded; this adds a firm local ceiling.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -33,6 +36,8 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 	username := user.Name
 	userNamespace := helpers.GetKubeUserNamespace()
 	selector := client.MatchingLabels{authv1alpha1.UserLabel: username}
+
+	var errs []error
 
 	// Delete steady-state secrets by name. They aren't labelled at creation,
 	// so the label-selector passes below won't catch them.
@@ -44,6 +49,7 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 		if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
 			logger.Error(err, "failed to delete fixed resource",
 				"kind", "Secret", "name", obj.GetName(), "namespace", obj.GetNamespace())
+			errs = append(errs, fmt.Errorf("delete Secret %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
 		}
 	}
 
@@ -51,10 +57,12 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 	var secrets corev1.SecretList
 	if err := r.List(ctx, &secrets, selector, client.InNamespace(userNamespace)); err != nil {
 		logger.Error(err, "failed to list user-labelled secrets", "namespace", userNamespace)
+		errs = append(errs, fmt.Errorf("list labelled Secrets in %s: %w", userNamespace, err))
 	} else {
 		for i := range secrets.Items {
 			if err := r.Delete(ctx, &secrets.Items[i]); client.IgnoreNotFound(err) != nil {
 				logger.Error(err, "failed to delete labelled secret", "name", secrets.Items[i].Name)
+				errs = append(errs, fmt.Errorf("delete Secret %s/%s: %w", secrets.Items[i].Namespace, secrets.Items[i].Name, err))
 			}
 		}
 	}
@@ -64,10 +72,12 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 	var csrs certv1.CertificateSigningRequestList
 	if err := r.List(ctx, &csrs, selector); err != nil {
 		logger.Error(err, "failed to list user-labelled CSRs")
+		errs = append(errs, fmt.Errorf("list labelled CSRs: %w", err))
 	} else {
 		for i := range csrs.Items {
 			if err := r.Delete(ctx, &csrs.Items[i]); client.IgnoreNotFound(err) != nil {
 				logger.Error(err, "failed to delete labelled CSR", "name", csrs.Items[i].Name)
+				errs = append(errs, fmt.Errorf("delete CSR %s: %w", csrs.Items[i].Name, err))
 			}
 		}
 	}
@@ -76,11 +86,13 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 	var rbs rbacv1.RoleBindingList
 	if err := r.List(ctx, &rbs, selector); err != nil {
 		logger.Error(err, "failed to list user RoleBindings")
+		errs = append(errs, fmt.Errorf("list labelled RoleBindings: %w", err))
 	} else {
 		for i := range rbs.Items {
 			if err := r.Delete(ctx, &rbs.Items[i]); client.IgnoreNotFound(err) != nil {
 				logger.Error(err, "failed to delete RoleBinding",
 					"name", rbs.Items[i].Name, "namespace", rbs.Items[i].Namespace)
+				errs = append(errs, fmt.Errorf("delete RoleBinding %s/%s: %w", rbs.Items[i].Namespace, rbs.Items[i].Name, err))
 			}
 		}
 	}
@@ -89,11 +101,15 @@ func CleanupUserResources(ctx context.Context, r client.Client, user *authv1alph
 	var crbs rbacv1.ClusterRoleBindingList
 	if err := r.List(ctx, &crbs, selector); err != nil {
 		logger.Error(err, "failed to list user ClusterRoleBindings")
+		errs = append(errs, fmt.Errorf("list labelled ClusterRoleBindings: %w", err))
 	} else {
 		for i := range crbs.Items {
 			if err := r.Delete(ctx, &crbs.Items[i]); client.IgnoreNotFound(err) != nil {
 				logger.Error(err, "failed to delete ClusterRoleBinding", "name", crbs.Items[i].Name)
+				errs = append(errs, fmt.Errorf("delete ClusterRoleBinding %s: %w", crbs.Items[i].Name, err))
 			}
 		}
 	}
+
+	return errors.Join(errs...)
 }

--- a/internal/controller/cleanup/finalizers_test.go
+++ b/internal/controller/cleanup/finalizers_test.go
@@ -2,6 +2,8 @@ package cleanup
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
@@ -13,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func newScheme(t *testing.T) *runtime.Scheme {
@@ -57,7 +60,9 @@ func TestCleanupUserResources_DeletesRotationArtifacts(t *testing.T) {
 		WithObjects(user, shadow, renewalCSR, otherShadow, aliceKey, aliceKubeconfig, bobKey).
 		Build()
 
-	CleanupUserResources(context.Background(), cli, user)
+	if err := CleanupUserResources(context.Background(), cli, user); err != nil {
+		t.Fatalf("CleanupUserResources returned unexpected error: %v", err)
+	}
 
 	mustNotFound := func(name string, obj client.Object) {
 		t.Helper()
@@ -81,4 +86,175 @@ func TestCleanupUserResources_DeletesRotationArtifacts(t *testing.T) {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bob-key", Namespace: "kubeuser"}})
 	mustExist("bob's shadow secret (different user, must survive)",
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "bob-rotation-temp", Namespace: "kubeuser"}})
+}
+
+// Regression test for issue #54: partial cleanup failures must surface as an
+// error so the caller can retain the finalizer and requeue. Silently swallowing
+// errors here previously caused permanent resource leaks — the finalizer would
+// be stripped even when Secrets, CSRs, or RoleBindings failed to delete.
+func TestCleanupUserResources_PropagatesDeletionErrors(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	user := &authv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: "alice", UID: "uid-123"}}
+
+	injected := errors.New("simulated API failure")
+
+	tests := []struct {
+		name         string
+		objects      []client.Object
+		funcs        interceptor.Funcs
+		wantContains string
+	}{
+		{
+			name: "fixed secret delete fails",
+			objects: []client.Object{
+				user,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-key", Namespace: "kubeuser"}},
+			},
+			funcs: interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if s, ok := obj.(*corev1.Secret); ok && s.Name == "alice-key" {
+						return injected
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			},
+			wantContains: "delete Secret kubeuser/alice-key",
+		},
+		{
+			name: "labelled secret list fails",
+			objects: []client.Object{
+				user,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name: "alice-rotation-temp", Namespace: "kubeuser",
+					Labels: map[string]string{"auth.openkube.io/user": "alice"},
+				}},
+			},
+			funcs: interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*corev1.SecretList); ok {
+						return injected
+					}
+					return c.List(ctx, list, opts...)
+				},
+			},
+			wantContains: "list labelled Secrets",
+		},
+		{
+			name: "csr delete fails",
+			objects: []client.Object{
+				user,
+				&certv1.CertificateSigningRequest{ObjectMeta: metav1.ObjectMeta{
+					Name:   "alice-renewal-uid12345",
+					Labels: map[string]string{"auth.openkube.io/user": "alice"},
+				}},
+			},
+			funcs: interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*certv1.CertificateSigningRequest); ok {
+						return injected
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			},
+			wantContains: "delete CSR alice-renewal-uid12345",
+		},
+		{
+			name: "rolebinding delete fails",
+			objects: []client.Object{
+				user,
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{
+					Name: "alice-rb", Namespace: "team-a",
+					Labels: map[string]string{"auth.openkube.io/user": "alice"},
+				}},
+			},
+			funcs: interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*rbacv1.RoleBinding); ok {
+						return injected
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			},
+			wantContains: "delete RoleBinding team-a/alice-rb",
+		},
+		{
+			name: "clusterrolebinding delete fails",
+			objects: []client.Object{
+				user,
+				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{
+					Name:   "alice-crb",
+					Labels: map[string]string{"auth.openkube.io/user": "alice"},
+				}},
+			},
+			funcs: interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*rbacv1.ClusterRoleBinding); ok {
+						return injected
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			},
+			wantContains: "delete ClusterRoleBinding alice-crb",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().
+				WithScheme(newScheme(t)).
+				WithObjects(tc.objects...).
+				WithInterceptorFuncs(tc.funcs).
+				Build()
+
+			err := CleanupUserResources(context.Background(), cli, user)
+			if err == nil {
+				t.Fatalf("issue #54 regression: expected error from CleanupUserResources when %q, got nil — finalizer would be stripped and resources leaked", tc.name)
+			}
+			if !errors.Is(err, injected) {
+				t.Errorf("expected error chain to wrap the injected failure via %%w, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantContains) {
+				t.Errorf("expected error to name the failing resource (%q), got %q", tc.wantContains, err.Error())
+			}
+		})
+	}
+}
+
+// Aggregation test: multiple simultaneous failures must all surface, so
+// operators see the full blast radius of a cleanup that could not complete.
+func TestCleanupUserResources_AggregatesMultipleErrors(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	user := &authv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: "alice", UID: "uid-123"}}
+	objects := []client.Object{
+		user,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-key", Namespace: "kubeuser"}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{
+			Name:   "alice-crb",
+			Labels: map[string]string{"auth.openkube.io/user": "alice"},
+		}},
+	}
+
+	failAll := errors.New("api down")
+	cli := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				return failAll
+			},
+		}).
+		Build()
+
+	err := CleanupUserResources(context.Background(), cli, user)
+	if err == nil {
+		t.Fatal("expected aggregated error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"alice-key", "alice-crb"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("aggregated error should name %q, got %q", want, msg)
+		}
+	}
 }

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -304,10 +304,15 @@ func (r *UserReconciler) handleDeletion(ctx context.Context, user *authv1alpha1.
 	logger.Info("User is being deleted, starting cleanup")
 
 	if helpers.ContainsString(user.Finalizers, authv1alpha1.UserFinalizer) {
-		// Step 1: Clean up all user resources BEFORE removing finalizer
-		// This ensures cleanup is complete even if finalizer removal fails
+		// Step 1: Clean up all user resources BEFORE removing finalizer.
+		// If any deletion fails, keep the finalizer so a later reconcile can
+		// retry — dropping it here would strip the safety net and orphan the
+		// resources the cleanup was unable to remove.
 		logger.Info("Cleaning up user resources")
-		cleanup.CleanupUserResources(ctx, r.Client, user)
+		if err := cleanup.CleanupUserResources(ctx, r.Client, user); err != nil {
+			logger.Error(err, "Cleanup failed, retaining finalizer to retry")
+			return err
+		}
 
 		// Step 2: Remove finalizer as the absolute last step
 		logger.Info("Removing finalizer")

--- a/internal/controller/user_controller_deletion_test.go
+++ b/internal/controller/user_controller_deletion_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	certv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// Regression test for issue #54: when CleanupUserResources fails, handleDeletion
+// must retain the finalizer and surface the error, so a later reconcile can
+// retry. Pre-fix, the cleanup error was silently discarded and the finalizer
+// was always removed, permanently orphaning any resource whose delete failed.
+func TestHandleDeletion_KeepsFinalizerWhenCleanupFails(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme, certv1.AddToScheme, rbacv1.AddToScheme, authv1alpha1.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("scheme: %v", err)
+		}
+	}
+
+	now := metav1.Now()
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "alice",
+			Namespace:         "default",
+			Finalizers:        []string{authv1alpha1.UserFinalizer},
+			DeletionTimestamp: &now,
+		},
+	}
+	leaked := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alice-key", Namespace: "kubeuser"}}
+
+	injected := errors.New("simulated etcd unavailable")
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user, leaked).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if s, ok := obj.(*corev1.Secret); ok && s.Name == "alice-key" {
+					return injected
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &UserReconciler{Client: cli, Scheme: scheme}
+
+	err := r.handleDeletion(context.Background(), user)
+	if err == nil {
+		t.Fatal("expected error from handleDeletion when cleanup fails, got nil — finalizer would be stripped and Secret orphaned")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("expected error chain to wrap the injected cleanup failure, got %v", err)
+	}
+
+	var persisted authv1alpha1.User
+	if getErr := cli.Get(context.Background(), types.NamespacedName{Name: "alice", Namespace: "default"}, &persisted); getErr != nil {
+		t.Fatalf("get user after failed deletion: %v", getErr)
+	}
+	found := false
+	for _, f := range persisted.Finalizers {
+		if f == authv1alpha1.UserFinalizer {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("issue #54 regression: finalizer %q was removed despite cleanup failure — resources would be orphaned; finalizers=%v",
+			authv1alpha1.UserFinalizer, persisted.Finalizers)
+	}
+}
+
+// Companion happy-path spec: when cleanup succeeds, the finalizer is removed
+// and the User is fully deleted. This pairs with the failure case above so a
+// reader sees both invariants side by side.
+func TestHandleDeletion_RemovesFinalizerWhenCleanupSucceeds(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme, certv1.AddToScheme, rbacv1.AddToScheme, authv1alpha1.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("scheme: %v", err)
+		}
+	}
+
+	now := metav1.Now()
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "alice",
+			Namespace:         "default",
+			Finalizers:        []string{authv1alpha1.UserFinalizer},
+			DeletionTimestamp: &now,
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user).
+		Build()
+
+	r := &UserReconciler{Client: cli, Scheme: scheme}
+
+	if err := r.handleDeletion(context.Background(), user); err != nil {
+		t.Fatalf("handleDeletion returned unexpected error: %v", err)
+	}
+
+	// With finalizer removed and DeletionTimestamp set, the fake client GCs the object.
+	err := cli.Get(context.Background(), types.NamespacedName{Name: "alice", Namespace: "default"}, &authv1alpha1.User{})
+	if err == nil {
+		t.Fatal("expected user to be gone after successful cleanup + finalizer removal")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #54.

`CleanupUserResources` returned nothing and silently logged per-resource
deletion failures. `handleDeletion` then removed the User's finalizer
unconditionally, so any Secret / CSR / RoleBinding whose `Delete` failed
(network partition, admission-webhook rejection, transient RBAC error,
throttled apiserver) was permanently orphaned — the finalizer safety net
was already gone by the time the next reconcile could have retried. This
violates the Kubernetes finalizer contract: `metadata.finalizers` is
stripped only after all owned resources are confirmed gone.

The fix changes `CleanupUserResources` to return `errors.Join` of every
per-resource failure and has `handleDeletion` return that error, so
controller-runtime requeues with backoff and the finalizer stays put on
etcd. Logging is unchanged so operators still see each individual failure
inline. Each aggregated error string names kind/namespace/name, so the
combined error identifies exactly which objects are at risk of leaking.
Blast radius is scoped to the failure path: on success everything behaves
as before (finalizer removed, User GC'd). No new dependencies.

### Regression coverage

Three regression tests were added:

- `TestCleanupUserResources_PropagatesDeletionErrors` (table-driven
  across the Secret / labelled-Secret-List / CSR / RoleBinding /
  ClusterRoleBinding failure paths) — asserts an error is returned and
  the injected cause is reachable via `errors.Is`, with the failing
  resource named in the message.
- `TestCleanupUserResources_AggregatesMultipleErrors` — proves multiple
  simultaneous failures all surface, so operators see the full blast
  radius of a partial cleanup.
- `TestHandleDeletion_KeepsFinalizerWhenCleanupFails` (plus a happy-path
  companion) — pins the controller-level invariant: on cleanup error the
  finalizer stays on the persisted object, guaranteeing a retry window.

All three fail deterministically on the pre-fix behavior (verified by
temporarily reverting the fix in a signature-compatible way; the
assertion messages name issue #54 directly). Errors are wrapped with
`fmt.Errorf(... %w, err)` so `errors.Is` still identifies the root cause
through the aggregated chain.

### Live verification on kind (K8s v1.35.0)

Reproduced end-to-end on the running kind cluster with the rebuilt
controller image:

1. Created `verify54-alice`; both `verify54-alice-key` and
   `verify54-alice-kubeconfig` provisioned; phase `Active`.
2. Applied a `ValidatingWebhookConfiguration` with an unreachable URL
   (`kubeuser-issue54-fixture.invalid`) and `failurePolicy: Fail`,
   targeting only DELETE on secrets labelled `test/block-delete=verify54`
   in the `kubeuser` namespace — so every `Delete` the operator issues on
   those two secrets is rejected by admission, and nothing else in the
   cluster is affected.
3. `kubectl delete user verify54-alice --wait=false`. Over the next 90s
   the leader logged `Cleanup failed, retaining finalizer to retry` 13
   times, each retry re-attempted both fixed secrets, controller-runtime
   backed off between passes, and the User object retained its
   `DeletionTimestamp` **and** its `auth.openkube.io/finalizer` through
   every pass. Both secrets survived.
4. Deleted the webhook. On the next backoff-driven pass the deletes
   succeeded, `CleanupUserResources` returned nil, the finalizer was
   removed, and the User plus both secrets were GC'd cleanly.

Pre-fix the User (and both secrets) would have been gone after step 3's
first pass, silently leaking the two secrets. The 13-retry loop that
kept everything intact is only possible because the error now propagates
back to `handleDeletion`.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `make lint` — 0 issues
- [x] New unit tests fail without the fix, pass with it (verified by
      simulating the swallow-and-remove behavior in
      `CleanupUserResources` and `handleDeletion` and rerunning)
- [x] Live kind verification: 13 blocked reconcile passes, finalizer
      retained on each, clean recovery once the block was removed