### PR TITLE
fix(renewal): scope concurrent-rotation counter to each RotationManager

### DIFF
--- a/docs/metrics-implementation.md
+++ b/docs/metrics-implementation.md
@@ -33,7 +33,7 @@ Metrics are integrated throughout the controller:
 #### Performance
 - `kubeuser_reconciliations_total` - Reconciliation attempts
 - `kubeuser_reconcile_duration_seconds` - Reconciliation duration
-- `kubeuser_workqueue_depth` - Work queue depth
+- `workqueue_depth{name="user"}` - Work queue depth (exposed by controller-runtime)
 
 #### Thundering Herd Protection
 - `kubeuser_concurrent_rotations` - Active rotations

--- a/hack/verify-metrics.sh
+++ b/hack/verify-metrics.sh
@@ -80,10 +80,10 @@ else
     echo -e "${YELLOW}⚠ kubeuser_users_total (will appear after users are created)${NC}"
 fi
 
-if echo "$METRICS" | grep -q "kubeuser_workqueue_depth"; then
-    echo -e "${GREEN}✓ kubeuser_workqueue_depth${NC}"
+if echo "$METRICS" | grep -q '^workqueue_depth{[^}]*name="user"'; then
+    echo -e "${GREEN}✓ workqueue_depth{name=\"user\"} (controller-runtime built-in)${NC}"
 else
-    echo -e "${YELLOW}⚠ kubeuser_workqueue_depth (will appear during reconciliation)${NC}"
+    echo -e "${YELLOW}⚠ workqueue_depth{name=\"user\"} (will appear during reconciliation)${NC}"
 fi
 echo ""
 

--- a/internal/controller/renewal/rotation.go
+++ b/internal/controller/renewal/rotation.go
@@ -46,9 +46,6 @@ const (
 	RotationStateError
 )
 
-// concurrentRotations tracks how many certificate rotations are in progress across all users.
-var concurrentRotations int64
-
 // RotationManager handles atomic certificate rotation with forward secrecy
 type RotationManager struct {
 	client        client.Client
@@ -56,6 +53,9 @@ type RotationManager struct {
 	signerName    string // Configurable signer for managed K8s support (EKS, GKE, AKS)
 	clusterName   string // Configurable kubeconfig cluster name
 	metrics       *metrics.Recorder
+	// concurrentRotations tracks in-flight rotations owned by this manager
+	// instance. Per-instance so parallel tests do not share a global counter.
+	concurrentRotations atomic.Int64
 }
 
 // NewRotationManager creates a new rotation manager with configurable signer
@@ -87,13 +87,13 @@ func (rm *RotationManager) RotateUserCertificate(ctx context.Context, user *auth
 	username := user.Name
 
 	// Track concurrent rotations
-	current := atomic.AddInt64(&concurrentRotations, 1)
+	current := rm.concurrentRotations.Add(1)
 	if rm.metrics != nil {
 		rm.metrics.SetConcurrentRotations(int(current))
 		rm.metrics.SetRotationQueueLength(int(current))
 	}
 	defer func() {
-		remaining := atomic.AddInt64(&concurrentRotations, -1)
+		remaining := rm.concurrentRotations.Add(-1)
 		if rm.metrics != nil {
 			rm.metrics.ObserveCertRotationDuration(user.Namespace, time.Since(start))
 			rm.metrics.SetConcurrentRotations(int(remaining))

--- a/internal/controller/renewal/rotation_test.go
+++ b/internal/controller/renewal/rotation_test.go
@@ -54,6 +54,34 @@ func TestRotationManager_generateUniqueCSRName(t *testing.T) {
 	}
 }
 
+// TestRotationManager_concurrentRotationsIsPerInstance pins the invariant that
+// each RotationManager owns its own in-flight counter. When the counter was a
+// package-level var, parallel tests observed each other's increments and one
+// manager's metric reading reflected the sum across every manager in the
+// process rather than its own workload.
+func TestRotationManager_concurrentRotationsIsPerInstance(t *testing.T) {
+	rmA := NewRotationManager(nil, nil, "", "", nil)
+	rmB := NewRotationManager(nil, nil, "", "", nil)
+
+	rmA.concurrentRotations.Add(1)
+	rmA.concurrentRotations.Add(1)
+
+	if got := rmA.concurrentRotations.Load(); got != 2 {
+		t.Errorf("rmA.concurrentRotations = %d, want 2", got)
+	}
+	if got := rmB.concurrentRotations.Load(); got != 0 {
+		t.Errorf("rmB.concurrentRotations = %d, want 0; counter leaked between RotationManager instances", got)
+	}
+
+	rmB.concurrentRotations.Add(5)
+	if got := rmA.concurrentRotations.Load(); got != 2 {
+		t.Errorf("rmA.concurrentRotations = %d after mutating rmB, want 2; counter leaked between RotationManager instances", got)
+	}
+	if got := rmB.concurrentRotations.Load(); got != 5 {
+		t.Errorf("rmB.concurrentRotations = %d, want 5", got)
+	}
+}
+
 func TestRotationManagerBuildKubeconfigUsesConfiguredClusterName(t *testing.T) {
 	rm := NewRotationManager(nil, nil, "", "production", nil)
 


### PR DESCRIPTION
## Summary

Fixes #56.

`concurrentRotations` was a package-level `int64` mutated via `sync/atomic` on every `RotateUserCertificate` call. Across parallel test runs (and any future multi-manager deployment) the increments from one manager leaked into another's readings, so metric writes for `kubeuser_concurrent_rotations` / `kubeuser_rotation_queue_length` reflected process-wide state rather than the manager that emitted them, and counter-based test assertions became order-dependent.

The counter is now an `atomic.Int64` field on `RotationManager`; the increment/decrement sites become `rm.concurrentRotations.Add(±1)`. Each manager owns its own counter. The metric method calls (`SetConcurrentRotations`, `SetRotationQueueLength`) are unchanged so the metric names, labels, and observed values are identical for a single-manager process — the semantic difference only shows up if you construct multiple `RotationManager` instances in the same process (e.g. in tests).

### Scope note on the other two items in the issue

The issue also called for removing the package-level `activeReconcileCount` counter and the misleading `kubeuser_workqueue_depth` metric. Both were already deleted in prior commits (`26ce43a` refactor(controller): remove activeReconcileCount counter and document drain ceiling; `1e5e793` refactor(metrics): remove redundant kubeuser_workqueue_depth gauge). This PR closes the remaining half — the `concurrentRotations` counter — and additionally drops two stale references to the already-removed `kubeuser_workqueue_depth` in `docs/metrics-implementation.md` and `hack/verify-metrics.sh`, replacing them with the controller-runtime built-in `workqueue_depth{name="user"}` that the changelog and Grafana dashboard already point to.

### Regression coverage

`TestRotationManager_concurrentRotationsIsPerInstance` in `internal/controller/renewal/rotation_test.go` constructs two `RotationManager` instances, mutates the counter on each, and asserts the two counters are independent. Verified that reverting the fix causes a compile failure (`rm.concurrentRotations undefined`) — the strongest possible regression guard: nobody can silently move the counter back to a package var without also breaking the test.

Grafana dashboard and Prometheus alerts (`config/grafana/kubeuser-dashboard.json`, `config/prometheus/alerts.yaml`) query by metric name and are unaffected.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `make lint` — 0 issues
- [x] New unit test fails on the reverted code (compile error confirming the field must exist) and passes with the fix
- [x] Live kind cluster verification (2-replica controller deployment, image `ghcr.io/openkube-hub/kubeuser-controller:latest` built with this branch):
  - Baseline metrics scrape (bearer-token via port-forward to each replica): `kubeuser_concurrent_rotations=0`, `kubeuser_rotation_queue_length=0` on both.
  - Triggered rotation by patching `valid-user` TTL `2160h → 4320h` (well above the ~10.8% no-op tolerance).
  - Background watchers on shadow-secret / CSR labels captured the full lifecycle: shadow `ADDED → DELETED`, CSR `ADDED → Approved → hasCert → DELETED`.
  - 500 ms metric poller caught the transition `kubeuser_concurrent_rotations 0 → 1 → 0` and `kubeuser_rotation_queue_length 0 → 1 → 0`, with `kubeuser_cert_rotations_total{status="success",user="valid-user"} 1` incrementing the moment the counter returned to zero.
  - Post-rotation state: user back to `Active`, new `ExpiryTime=2027-02-18` (matches 4320h), both user secrets intact, no orphaned shadow secret or CSR.