### PR TITLE
fix(renewal): verify shadow/key secret ownership before reuse to prevent key-planting impersonation

### DIFF
--- a/internal/controller/certs/certs.go
+++ b/internal/controller/certs/certs.go
@@ -78,7 +78,7 @@ func EnsureCertKubeconfigWithDuration(ctx context.Context, r client.Client, user
 	}
 
 	// Stage 3: Ensure private key exists
-	keyPEM, err := ensurePrivateKey(ctx, r, keySecretName, userNamespace)
+	keyPEM, err := ensurePrivateKey(ctx, r, user, keySecretName, userNamespace)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to ensure private key: %w", err)
 	}
@@ -151,16 +151,23 @@ func ensureNamespace(ctx context.Context, r client.Client, namespace string) err
 	return nil
 }
 
-// ensurePrivateKey loads an existing private key or generates a new 2048-bit RSA key and persists it
-// Returns the key PEM bytes
-func ensurePrivateKey(ctx context.Context, r client.Client, name, namespace string) ([]byte, error) {
+// ensurePrivateKey loads an existing private key or generates a new 2048-bit RSA key and persists it.
+// An existing key Secret is only reused when its OwnerReferences confirm this
+// User created it; otherwise it is refused rather than silently used or
+// overwritten, since either behaviour would allow a caller with `create` on
+// Secrets in the operator namespace to pre-plant key material that ends up
+// authenticating the target User.
+func ensurePrivateKey(ctx context.Context, r client.Client, user *authv1alpha1.User, name, namespace string) ([]byte, error) {
 	logger := logf.FromContext(ctx)
 
 	var keySecret corev1.Secret
 	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &keySecret)
 
 	if err == nil {
-		// Key already exists
+		if !helpers.IsOwnedByUser(&keySecret, user) {
+			return nil, fmt.Errorf("key secret %s/%s is not owned by user %s (uid=%s); refusing to reuse potentially planted key material",
+				namespace, name, user.Name, user.UID)
+		}
 		keyPEM := keySecret.Data["key.pem"]
 		if keyPEM == nil {
 			return nil, fmt.Errorf("key secret exists but key.pem data is missing")
@@ -189,6 +196,16 @@ func ensurePrivateKey(ctx context.Context, r client.Client, name, namespace stri
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         authv1alpha1.GroupVersion.String(),
+					Kind:               "User",
+					Name:               user.Name,
+					UID:                user.UID,
+					Controller:         &[]bool{true}[0],
+					BlockOwnerDeletion: &[]bool{true}[0],
+				},
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{"key.pem": keyPEM},

--- a/internal/controller/certs/certs_test.go
+++ b/internal/controller/certs/certs_test.go
@@ -1,8 +1,17 @@
 package certs
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetRotationThreshold(t *testing.T) {
@@ -189,6 +198,129 @@ func TestBuildCertKubeconfigWithClusterName(t *testing.T) {
 		if !contains(got, expected) {
 			t.Errorf("BuildCertKubeconfigWithClusterName() missing expected string: %s", expected)
 		}
+	}
+}
+
+// TestEnsurePrivateKey_RefusesUnownedKeySecret is the regression guard for the
+// initial-issuance variant of issue #115. Before the fix, ensurePrivateKey used
+// any pre-existing `<user>-key` Secret verbatim. A caller with `create` on
+// Secrets in the operator namespace could plant a key Secret before the target
+// User was first reconciled and the operator would seal that attacker-owned
+// key into the generated kubeconfig on initial issuance. The fixed code refuses
+// to reuse a key Secret whose OwnerReferences do not confirm this User created
+// it.
+func TestEnsurePrivateKey_RefusesUnownedKeySecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+
+	impostor := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alice-key",
+			Namespace: "kubeuser",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"key.pem": []byte("attacker-controlled-key-material")},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(impostor).Build()
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alice",
+			UID:  "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	_, err := ensurePrivateKey(context.Background(), cli, user, "alice-key", "kubeuser")
+	if err == nil {
+		t.Fatal("ensurePrivateKey accepted a Secret with no OwnerReferences — planted attacker key would be used for initial issuance")
+	}
+	if !strings.Contains(err.Error(), "not owned by user") {
+		t.Errorf("error = %v, want it to mention the ownership refusal", err)
+	}
+}
+
+// TestEnsurePrivateKey_RefusesKeySecretOwnedByOtherUser guards against the
+// UID-mismatch case (e.g. leftover from a deleted-and-recreated User with the
+// same name, or an attacker who guessed the schema).
+func TestEnsurePrivateKey_RefusesKeySecretOwnedByOtherUser(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+
+	impostor := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alice-key",
+			Namespace: "kubeuser",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: authv1alpha1.GroupVersion.String(),
+					Kind:       "User",
+					Name:       "alice",
+					UID:        "some-other-uid",
+				},
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"key.pem": []byte("attacker-controlled-key-material")},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(impostor).Build()
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alice",
+			UID:  "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	_, err := ensurePrivateKey(context.Background(), cli, user, "alice-key", "kubeuser")
+	if err == nil {
+		t.Fatal("ensurePrivateKey accepted a Secret owned by a different UID — key material from a stale/foreign User was used")
+	}
+}
+
+// TestEnsurePrivateKey_SetsOwnerReferencesOnCreate is the paired invariant: the
+// read-path trust check only works if the create path plants a matching
+// OwnerReference. Without this, every subsequent reconcile of the same User
+// would refuse the freshly created key.
+func TestEnsurePrivateKey_SetsOwnerReferencesOnCreate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alice",
+			UID:  "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	if _, err := ensurePrivateKey(context.Background(), cli, user, "alice-key", "kubeuser"); err != nil {
+		t.Fatalf("ensurePrivateKey (create path): %v", err)
+	}
+
+	got := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Name: "alice-key", Namespace: "kubeuser"}, got); err != nil {
+		t.Fatalf("get created key secret: %v", err)
+	}
+	if len(got.OwnerReferences) != 1 {
+		t.Fatalf("created key secret OwnerReferences count = %d, want 1", len(got.OwnerReferences))
+	}
+	ref := got.OwnerReferences[0]
+	if ref.Kind != "User" || ref.UID != user.UID {
+		t.Errorf("OwnerReference = (Kind=%q, UID=%q), want (User, %q)", ref.Kind, ref.UID, user.UID)
+	}
+	if ref.APIVersion != authv1alpha1.GroupVersion.String() {
+		t.Errorf("OwnerReference.APIVersion = %q, want %q (empty APIVersion causes GC to skip the ref)", ref.APIVersion, authv1alpha1.GroupVersion.String())
+	}
+
+	// Round-trip: a follow-up call must recognise the just-created secret as trusted.
+	if _, err := ensurePrivateKey(context.Background(), cli, user, "alice-key", "kubeuser"); err != nil {
+		t.Errorf("second ensurePrivateKey call refused the operator-created key: %v", err)
 	}
 }
 

--- a/internal/controller/helpers/helpers.go
+++ b/internal/controller/helpers/helpers.go
@@ -334,6 +334,22 @@ func RemoveString(slice []string, s string) []string {
 	return result
 }
 
+// IsOwnedByUser reports whether obj carries an OwnerReference whose Kind is
+// "User" and whose UID matches the given User. Used as a trust check on
+// resources with deterministic names (shadow Secret, key Secret) so a resource
+// planted by someone other than the operator is not silently resumed from.
+func IsOwnedByUser(obj metav1.Object, user *authv1alpha1.User) bool {
+	if obj == nil || user == nil {
+		return false
+	}
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Kind == "User" && ref.UID == user.UID {
+			return true
+		}
+	}
+	return false
+}
+
 // SemanticTimePtrMatch compares two *metav1.Time pointers safely, handling nil cases.
 // Returns true if both pointers are semantically equal (both nil or both point to equal times).
 func SemanticTimePtrMatch(a, b *metav1.Time) bool {

--- a/internal/controller/helpers/helpers_test.go
+++ b/internal/controller/helpers/helpers_test.go
@@ -3,6 +3,11 @@ package helpers
 import (
 	"strings"
 	"testing"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestGetKubeconfigClusterNameDefault(t *testing.T) {
@@ -126,6 +131,88 @@ func TestValidateKubeconfigClusterName(t *testing.T) {
 			err := ValidateKubeconfigClusterName(tt.clusterName)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ValidateKubeconfigClusterName(%q) error = %v, wantErr %v", tt.clusterName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestIsOwnedByUser pins the trust check used at the shadow-secret and key-secret
+// read paths. A false positive here silently accepts externally planted key
+// material as if the operator had produced it, which is the class of bug the
+// helper exists to prevent.
+func TestIsOwnedByUser(t *testing.T) {
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alice",
+			UID:  types.UID("legit-uid-1234"),
+		},
+	}
+
+	tests := []struct {
+		name string
+		obj  metav1.Object
+		user *authv1alpha1.User
+		want bool
+	}{
+		{
+			name: "matching kind and UID",
+			obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Kind: "User", UID: "legit-uid-1234"}},
+			}},
+			user: user,
+			want: true,
+		},
+		{
+			name: "no owner references at all",
+			obj:  &corev1.Secret{ObjectMeta: metav1.ObjectMeta{}},
+			user: user,
+			want: false,
+		},
+		{
+			name: "wrong UID (impersonation attempt with correct Kind)",
+			obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Kind: "User", UID: "attacker-uid"}},
+			}},
+			user: user,
+			want: false,
+		},
+		{
+			name: "wrong Kind (matching UID but different Kind)",
+			obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Kind: "ConfigMap", UID: "legit-uid-1234"}},
+			}},
+			user: user,
+			want: false,
+		},
+		{
+			name: "match present alongside unrelated refs",
+			obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "Deployment", UID: "somethin-else"},
+					{Kind: "User", UID: "legit-uid-1234"},
+				},
+			}},
+			user: user,
+			want: true,
+		},
+		{
+			name: "nil object",
+			obj:  nil,
+			user: user,
+			want: false,
+		},
+		{
+			name: "nil user",
+			obj:  &corev1.Secret{},
+			user: nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOwnedByUser(tt.obj, tt.user); got != tt.want {
+				t.Errorf("IsOwnedByUser() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/controller/renewal/rotation.go
+++ b/internal/controller/renewal/rotation.go
@@ -112,6 +112,25 @@ func (rm *RotationManager) RotateUserCertificate(ctx context.Context, user *auth
 
 	// If Shadow Secret exists, we MUST be in Renewing state regardless of User.Status.Phase
 	if shadowExists {
+		// Trust check: any resource sitting at the shadow-secret name that this
+		// operator did not create is treated as externally planted. Resuming
+		// rotation from it would build a CSR against the planted private key and
+		// write that key into <user>-kubeconfig on the atomic flip.
+		if !helpers.IsOwnedByUser(shadowSecret, user) {
+			logger.Error(nil, "Shadow Secret is not owned by this User, refusing to resume rotation from it",
+				"shadowSecret", shadowSecret.Name, "userUID", user.UID)
+			rm.eventRecorder.Event(user, "Warning", "ShadowSecretUntrusted",
+				"Found a shadow secret not owned by this User; deleting it and refusing to resume rotation")
+			if rm.metrics != nil {
+				rm.metrics.RecordRotationError(user.Namespace, username, "shadow_secret_untrusted")
+			}
+			if err := rm.deleteShadowSecret(ctx, username); err != nil {
+				return false, nil, fmt.Errorf("failed to delete untrusted shadow secret: %w", err)
+			}
+			return false, nil, fmt.Errorf("shadow secret %s is not owned by user %s (uid=%s); deleted and refusing to resume",
+				shadowSecret.Name, username, user.UID)
+		}
+
 		logger.Info("Shadow Secret found, ensuring Renewing state", "shadowSecret", shadowSecret.Name)
 
 		// Force status to reflect the rotation state (Shadow Secret as Source of Truth)
@@ -685,11 +704,23 @@ func (rm *RotationManager) atomicSecretUpdate(ctx context.Context, user *authv1a
 		oldCfgSecret = nil // No existing secret to backup
 	}
 
-	// Update key secret first with ResourceVersion checking
+	// Update key secret first with ResourceVersion checking. Owner refs are set
+	// so ensurePrivateKey's trust check on the next reconcile recognizes this
+	// secret as operator-created rather than treating it as externally planted.
 	keySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      keySecretName,
 			Namespace: userNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         authv1alpha1.GroupVersion.String(),
+					Kind:               "User",
+					Name:               user.Name,
+					UID:                user.UID,
+					Controller:         &[]bool{true}[0],
+					BlockOwnerDeletion: &[]bool{true}[0],
+				},
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{

--- a/internal/controller/renewal/rotation_test.go
+++ b/internal/controller/renewal/rotation_test.go
@@ -7,10 +7,13 @@ import (
 	"time"
 
 	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	"github.com/openkube-hub/KubeUser/internal/controller/helpers"
 	certv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -538,6 +541,199 @@ func TestRotationManager_CSRHasValidOwnerReference(t *testing.T) {
 	// must still block foreground deletion so orphaned certs cannot outlive the User.
 	if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
 		t.Errorf("OwnerReference.BlockOwnerDeletion = %v, want *true", ref.BlockOwnerDeletion)
+	}
+}
+
+// TestRotationManager_RotateUserCertificate_RejectsUnownedShadowSecret is the
+// regression guard for CVE-class issue #115: RotateUserCertificate previously
+// treated any Secret sitting at `<user>-rotation-temp` as prior operator state
+// and resumed the rotation from its `key.pem`. A caller with `create` on
+// Secrets in the operator namespace could plant their own private key, wait for
+// any legitimate rotation trigger, and the operator would build a CSR against
+// the planted key and write that key into `<user>-kubeconfig` on the atomic
+// flip — silently authenticating the target User with attacker-held key
+// material. This test drives the exact pre-plant scenario and asserts the
+// operator refuses to resume, deletes the impostor, and does not create a CSR.
+func TestRotationManager_RotateUserCertificate_RejectsUnownedShadowSecret(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+	if err := certv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("certv1 scheme: %v", err)
+	}
+
+	// Impostor shadow secret with attacker key and no OwnerReference back to
+	// the target User. This is the exact shape reproduced on the live cluster
+	// in the issue's PoC (labels + csr-name annotation to look legitimate).
+	impostor := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alice-rotation-temp",
+			Namespace: "kubeuser",
+			Labels: map[string]string{
+				authv1alpha1.UserLabel:     "alice",
+				authv1alpha1.RotationLabel: "true",
+				authv1alpha1.ShadowLabel:   "true",
+			},
+			Annotations: map[string]string{
+				authv1alpha1.CSRNameAnnotation: "alice-attacker-csr",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"key.pem": []byte("attacker-controlled-key-material")},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(impostor).Build()
+	recorder := record.NewFakeRecorder(10)
+	rm := NewRotationManager(cli, recorder, "kubernetes.io/kube-apiserver-client", "", nil)
+
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alice",
+			Namespace: "kubeuser",
+			UID:       "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	_, _, err := rm.RotateUserCertificate(context.Background(), user, time.Hour)
+	if err == nil {
+		t.Fatal("RotateUserCertificate accepted an unowned shadow secret — attacker key would be used for the next CSR and written into the user's kubeconfig")
+	}
+	if !strings.Contains(err.Error(), "not owned by user") {
+		t.Errorf("error = %v, want it to mention the ownership refusal", err)
+	}
+
+	// The impostor must be removed so a follow-up reconcile starts a clean
+	// rotation instead of loop-refusing forever.
+	got := &corev1.Secret{}
+	getErr := cli.Get(context.Background(), client.ObjectKey{Name: "alice-rotation-temp", Namespace: "kubeuser"}, got)
+	if !apierrors.IsNotFound(getErr) {
+		t.Errorf("impostor shadow secret still present after refusal (get err = %v); operator would keep tripping the same trust check", getErr)
+	}
+
+	// No CSR must have been created — reaching CSR creation means the attacker
+	// key already flowed into a public-key artefact ready for signer approval.
+	csrList := &certv1.CertificateSigningRequestList{}
+	if err := cli.List(context.Background(), csrList); err != nil {
+		t.Fatalf("list CSRs: %v", err)
+	}
+	if len(csrList.Items) != 0 {
+		t.Errorf("expected 0 CSRs after refusing untrusted shadow, got %d: %+v", len(csrList.Items), csrList.Items)
+	}
+
+	// Operator visibility: an event must fire so cluster admins can catch this in audits.
+	select {
+	case ev := <-recorder.Events:
+		if !strings.Contains(ev, "ShadowSecretUntrusted") {
+			t.Errorf("event %q does not name the trust-check reason", ev)
+		}
+	default:
+		t.Error("no event emitted for refusal — this attack must be observable to operators")
+	}
+}
+
+// TestRotationManager_RotateUserCertificate_AcceptsOwnedShadowSecret is the
+// symmetric guard: the trust check must not falsely reject shadow secrets the
+// operator itself created. A false positive here would break every in-progress
+// rotation, effectively DoSing the operator.
+func TestRotationManager_RotateUserCertificate_AcceptsOwnedShadowSecret(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+	if err := certv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("certv1 scheme: %v", err)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	recorder := record.NewFakeRecorder(10)
+	rm := NewRotationManager(cli, recorder, "kubernetes.io/kube-apiserver-client", "", nil)
+
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alice",
+			Namespace: "kubeuser",
+			UID:       "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	// Production WRITE path — creates a shadow secret owned by this User.
+	if err := rm.createShadowSecretForRotation(context.Background(), user); err != nil {
+		t.Fatalf("createShadowSecretForRotation: %v", err)
+	}
+
+	// Second call should treat the operator-created secret as trusted and
+	// progress past the trust check. It will still fail further down
+	// (e.g. approval subresource is not implemented by the fake client), but
+	// the error must NOT be the ownership refusal.
+	_, _, err := rm.RotateUserCertificate(context.Background(), user, time.Hour)
+	if err != nil && strings.Contains(err.Error(), "not owned by user") {
+		t.Fatalf("operator-created shadow secret was refused as untrusted: %v", err)
+	}
+
+	// The trusted shadow secret must survive — deleting it here would abort a
+	// legitimate in-progress rotation.
+	got := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Name: "alice-rotation-temp", Namespace: "kubeuser"}, got); err != nil {
+		t.Fatalf("legitimate shadow secret was deleted by trust check: %v", err)
+	}
+}
+
+// TestRotationManager_AtomicSecretUpdate_KeySecretCarriesOwnerReference guards
+// the second half of the fix: rotation writes the new private key back to
+// `<user>-key` via atomicSecretUpdate; if that write drops the OwnerReference
+// then ensurePrivateKey's trust check refuses the same key on the next
+// initial-issuance-style reconcile and the operator wedges. The invariant is
+// therefore "rotation-time key writes must be adoptable by the read path".
+func TestRotationManager_AtomicSecretUpdate_KeySecretCarriesOwnerReference(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+
+	// Seed the CA ConfigMap so getClusterCA succeeds in the test env.
+	caCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: "default"},
+		Data:       map[string]string{"ca.crt": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(caCM).Build()
+	rm := NewRotationManager(cli, record.NewFakeRecorder(10), "kubernetes.io/kube-apiserver-client", "", nil)
+
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alice",
+			Namespace: "kubeuser",
+			UID:       "12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	newKeyPEM := []byte("-----BEGIN RSA PRIVATE KEY-----\nAAAA\n-----END RSA PRIVATE KEY-----")
+	signedCert := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+
+	if err := rm.atomicSecretUpdate(context.Background(), user, newKeyPEM, signedCert); err != nil {
+		t.Fatalf("atomicSecretUpdate: %v", err)
+	}
+
+	got := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Name: "alice-key", Namespace: "kubeuser"}, got); err != nil {
+		t.Fatalf("get key secret: %v", err)
+	}
+	if len(got.OwnerReferences) != 1 {
+		t.Fatalf("key secret OwnerReferences count = %d, want 1 — without an owner ref the read-side trust check would refuse this key on next reconcile", len(got.OwnerReferences))
+	}
+	ref := got.OwnerReferences[0]
+	if !helpers.IsOwnedByUser(got, user) {
+		t.Errorf("key secret OwnerReference = (Kind=%q, UID=%q), want the shared IsOwnedByUser check to accept it", ref.Kind, ref.UID)
+	}
+	if ref.APIVersion != authv1alpha1.GroupVersion.String() {
+		t.Errorf("key secret OwnerReference.APIVersion = %q, want %q (empty APIVersion causes GC to skip the ref)", ref.APIVersion, authv1alpha1.GroupVersion.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #115.

`RotateUserCertificate` treated the existence of `<user>-rotation-temp` as proof that a prior operator run had staged a rotation and resumed from whatever `key.pem` and `csr-name` annotation it found there. A caller with `create` on Secrets in the operator namespace could plant a shadow Secret carrying an attacker-controlled private key; on the next legitimate rotation trigger the operator would build a CSR against that key, auto-approve it, and on the atomic flip write both the signed certificate *and* the attacker's private key into `<user>-kubeconfig` — silently authenticating every subsequent use of the target User with attacker-held key material. Because the resulting kubeconfig is internally consistent (cert and key match), the legitimate user notices nothing, and the impersonation is fully stealthy. The same "trust by name" pattern in `ensurePrivateKey` made the initial-issuance path exploitable against `<user>-key` if planted before the User was first reconciled.

The fix adds a shared `helpers.IsOwnedByUser` trust check keyed on `(Kind=User, UID)` and applies it at both entry points. The check mirrors the exact `OwnerReference` the operator already writes on create (`createShadowSecretForRotation`, `ensureCSRExists`, RBAC bindings), so operator-owned resources round-trip cleanly and only externally planted resources are refused:

- `RotateUserCertificate` now verifies the shadow Secret's ownership before resuming; on mismatch it deletes the impostor, emits a `Warning` event `ShadowSecretUntrusted`, records a `shadow_secret_untrusted` rotation-error metric, and returns an error so the next reconcile starts a clean rotation.
- `ensurePrivateKey` now takes the target `User`, refuses any existing `<user>-key` Secret whose `OwnerReferences` do not confirm this User created it, and stamps a matching `OwnerReference` on the create path.
- `atomicSecretUpdate` stamps the same `OwnerReference` on the rotation-time key write so the read-side trust check accepts operator-created keys on every subsequent reconcile.

The reporter's suggestion #4 (one shared helper across all call sites) is honoured — `helpers.IsOwnedByUser` is now the single source of truth for this check and future resources can adopt it.

### Blast radius

- **In-flight rotations on upgrade**: shadow Secrets owned by the operator already carry the matching `OwnerReference` (`createShadowSecretForRotation`), so ongoing rotations resume cleanly.
- **Existing `<user>-key` Secrets from prior versions**: created without `OwnerReferences`. After upgrade the operator refuses to reuse them and reconciliation errors until the operator either (a) patches the Secret to add an `OwnerReference` back to its User, or (b) deletes the Secret so a fresh key is generated on the next reconcile (which invalidates the old cert; a new one is written to `<user>-kubeconfig` on the same reconcile). Since the project is pre-1.0 (v0.1.0 milestone), surfacing this as a hard failure rather than adopting silently was chosen deliberately — silent adoption would leave the pre-plant-before-first-reconcile window open, which is exactly what the reporter's suggestion #3 warns against ("log and refuse … do not silently overwrite either").

### Regression coverage

Six new tests, colocated with the package they guard and named after the invariant they protect:

- `TestIsOwnedByUser` (helpers) — truth table for the shared trust check: matching UID, no owner refs, wrong UID, wrong Kind, match alongside unrelated refs, nil inputs.
- `TestRotationManager_RotateUserCertificate_RejectsUnownedShadowSecret` — reproduces the exploit's pre-plant shape (labels + `csr-name` annotation, no matching `OwnerReference`), asserts the operator refuses to resume, deletes the impostor, creates no CSR, and emits `ShadowSecretUntrusted`.
- `TestRotationManager_RotateUserCertificate_AcceptsOwnedShadowSecret` — symmetric guard so the trust check does not false-positive on operator-created shadows and DoS every legitimate in-flight rotation.
- `TestRotationManager_AtomicSecretUpdate_KeySecretCarriesOwnerReference` — pins the invariant that rotation-time key writes carry the `OwnerReference` the read-side check needs; without this, `ensurePrivateKey` would refuse the freshly rotated key on the next reconcile.
- `TestEnsurePrivateKey_RefusesUnownedKeySecret` and `TestEnsurePrivateKey_RefusesKeySecretOwnedByOtherUser` — regression guards for the initial-issuance variant against no-owner-refs and UID-mismatch planted keys.
- `TestEnsurePrivateKey_SetsOwnerReferencesOnCreate` — paired invariant so the create path stamps the ref the read path requires; verified with a round-trip second call.

Each new test was verified to fail on the reverted code and pass on the fixed code before merging the pieces back together.

### Live verification on kind

**Exploit blocked (reproduction of the issue's PoC):**
- Pre-planted `live-115-rotation-temp` with an attacker RSA key and no owner refs, then bumped TTL to trigger rotation.
- Shadow-secret watch showed: impostor `ADDED (ownerRefs=0)` → refused and `DELETED` → legit `ADDED (ownerRefs=1)` → `DELETED` after normal cleanup.
- Controller log carried `"Shadow Secret is not owned by this User, refusing to resume rotation from it"` with the target `userUID`.
- Post-rotation `<user>-kubeconfig`, embedded `client-key-data`, and `<user>-key` all share the new legit key pubkey MD5 `4dab0fbacdac15af9077c22bfda2d22c`; the attacker's key MD5 `8306d35a868f817be3231b90f6a01ff1` appears nowhere.

**Golden path unchanged:**
- Created a normal `golden-user`; kubeconfig extracts and `kubectl auth whoami` returns `golden-user`; RBAC honoured (`can-i list pods`=yes, `can-i create pods`=no).
- Confirmed `<user>-key` carries the operator's `OwnerReference` on create (fix's create-path invariant).
- Bumped `spec.auth.ttl` 25h → 200h: cert MD5 changed, credential-id X509SHA256 changed, new `notAfter` matches ~200h, updated kubeconfig still authenticates.
- **`<user>-key` owner ref preserved through the atomic flip** (fix's `atomicSecretUpdate` invariant).
- After `kubectl delete user`, finalizer cleanup removed `<user>-key`, `<user>-kubeconfig`, ClusterRoleBinding, and the initial CSR.

### Adjacent finding, not addressed here

The `ShadowSecretUntrusted` warning event is constructed but the K8s API server rejected the write with `events is forbidden: … cannot create resource "events" in the namespace "default"`. Cluster-scoped Users route events to `default` and the operator's ClusterRole does not currently grant `create` on events there. The trust-check itself still fires (visible in controller logs and via the `shadow_secret_untrusted` metric); the missing event is a pre-existing RBAC gap worth filing separately.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `make lint` — 0 issues
- [x] New unit tests fail without the fix, pass with it (verified by independently reverting each of the three fix pieces)
- [x] Live kind exploit reproduction — attacker key refused, rotation completes with fresh operator-generated key, kubeconfig contains no attacker material
- [x] Live kind golden path — create → kubeconfig works → TTL bump rotates → kubeconfig re-auth works → delete cleans up
- [ ] Reviewer: sanity-check the upgrade path for deployments carrying legacy `<user>-key` Secrets without `OwnerReferences` (patch or recreate before rolling out)
- [ ] Follow-up issue for the `events` RBAC gap so `ShadowSecretUntrusted` becomes visible via `kubectl get events`