### PR TITLE
fix(security): reject pre-planted CSRs so operator never signs one bound to an attacker key

### DIFF
--- a/internal/controller/certs/certs.go
+++ b/internal/controller/certs/certs.go
@@ -218,7 +218,7 @@ func ensureSignedCertificate(ctx context.Context, r client.Client, user *authv1a
 	}
 
 	// Get or create CSR
-	csr, err := getOrCreateCSR(ctx, r, csrName, username, csrPEM, duration, signerName)
+	csr, err := getOrCreateCSR(ctx, r, csrName, username, csrPEM, keyPEM, duration, signerName)
 	if err != nil {
 		return nil, false, err
 	}
@@ -229,7 +229,7 @@ func ensureSignedCertificate(ctx context.Context, r client.Client, user *authv1a
 
 	// Approve CSR if needed
 	if needsApproval(csr) {
-		if err := approveCSR(ctx, r, csr, csrName); err != nil {
+		if err := approveCSR(ctx, r, csr, csrName, username, keyPEM, signerName); err != nil {
 			return nil, false, err
 		}
 		return nil, true, nil
@@ -247,19 +247,29 @@ func ensureSignedCertificate(ctx context.Context, r client.Client, user *authv1a
 	return csr.Status.Certificate, false, nil
 }
 
-// getOrCreateCSR retrieves an existing CSR or creates a new one
-// Returns (csr, error) where csr is nil if a new CSR was just created
-func getOrCreateCSR(ctx context.Context, r client.Client, csrName, username string, csrPEM []byte, duration time.Duration, signerName string) (*certv1.CertificateSigningRequest, error) {
+// getOrCreateCSR retrieves an existing CSR or creates a new one.
+// If a CSR already exists under the deterministic name, it is validated against
+// the operator's stored private key and expected spec; a mismatch (which would
+// indicate an attacker pre-planted a CSR to be signed under our name) triggers
+// delete-and-recreate rather than reuse.
+// Returns (csr, error) where csr is nil if a new CSR was just created.
+func getOrCreateCSR(ctx context.Context, r client.Client, csrName, username string, csrPEM, keyPEM []byte, duration time.Duration, signerName string) (*certv1.CertificateSigningRequest, error) {
 	logger := logf.FromContext(ctx)
 
 	var csr certv1.CertificateSigningRequest
 	err := r.Get(ctx, types.NamespacedName{Name: csrName}, &csr)
 
 	if err == nil {
-		return &csr, nil
-	}
-
-	if !apierrors.IsNotFound(err) {
+		if valErr := validateOperatorCSR(&csr, username, signerName, keyPEM); valErr != nil {
+			logger.Info("Existing CSR failed operator validation, replacing", "csr", csrName, "reason", valErr.Error())
+			if delErr := r.Delete(ctx, &csr); delErr != nil && !apierrors.IsNotFound(delErr) {
+				return nil, fmt.Errorf("failed to delete untrusted CSR %s: %w", csrName, delErr)
+			}
+			// Fall through to create a fresh CSR bound to the operator's key.
+		} else {
+			return &csr, nil
+		}
+	} else if !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get CSR: %w", err)
 	}
 
@@ -288,6 +298,38 @@ func getOrCreateCSR(ctx context.Context, r client.Client, csrName, username stri
 	return nil, nil
 }
 
+// validateOperatorCSR checks that a CSR is one the operator would have created
+// for this user: expected signer, ClientAuth-only usages, CommonName == user,
+// no Subject.Organization, and — critically — a public key matching the
+// operator-held private key. Any failure means the CSR is not trustworthy for
+// auto-approval.
+func validateOperatorCSR(csr *certv1.CertificateSigningRequest, username, signerName string, keyPEM []byte) error {
+	if csr.Spec.SignerName != signerName {
+		return fmt.Errorf("signer %q does not match expected %q", csr.Spec.SignerName, signerName)
+	}
+	if len(csr.Spec.Usages) != 1 || csr.Spec.Usages[0] != certv1.UsageClientAuth {
+		return fmt.Errorf("usages %v do not match expected [%s]", csr.Spec.Usages, certv1.UsageClientAuth)
+	}
+	block, _ := pem.Decode(csr.Spec.Request)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return errors.New("invalid CSR PEM in Spec.Request")
+	}
+	req, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse CSR: %w", err)
+	}
+	if req.Subject.CommonName != username {
+		return fmt.Errorf("CommonName %q does not match user %q", req.Subject.CommonName, username)
+	}
+	if len(req.Subject.Organization) > 0 {
+		return fmt.Errorf("Subject.Organization %v is not permitted (operator never sets groups)", req.Subject.Organization)
+	}
+	if err := helpers.VerifyCSRMatchesKey(csr.Spec.Request, keyPEM); err != nil {
+		return err
+	}
+	return nil
+}
+
 // needsApproval checks if a CSR needs approval
 func needsApproval(csr *certv1.CertificateSigningRequest) bool {
 	for _, c := range csr.Status.Conditions {
@@ -298,10 +340,19 @@ func needsApproval(csr *certv1.CertificateSigningRequest) bool {
 	return true
 }
 
-// approveCSR auto-approves a CSR
-func approveCSR(ctx context.Context, r client.Client, csr *certv1.CertificateSigningRequest, csrName string) error {
+// approveCSR auto-approves a CSR after validating it belongs to the operator.
+// The validation guards against approving a pre-planted attacker CSR (see #114):
+// the request must use the expected signer, ClientAuth-only usages, match the
+// user's CommonName with no Subject.Organization, and — critically — its
+// public key must match the operator-held private key.
+func approveCSR(ctx context.Context, r client.Client, csr *certv1.CertificateSigningRequest, csrName, username string, keyPEM []byte, signerName string) error {
 	logger := logf.FromContext(ctx)
-	logger.Info("Auto-approving CSR", "csr", csrName)
+
+	if err := validateOperatorCSR(csr, username, signerName, keyPEM); err != nil {
+		return fmt.Errorf("refusing to approve CSR %s: %w", csrName, err)
+	}
+
+	logger.Info("Auto-approving validated CSR", "csr", csrName)
 
 	csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
 		Type:           certv1.CertificateApproved,

--- a/internal/controller/certs/csr_security_test.go
+++ b/internal/controller/certs/csr_security_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package certs
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	certv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// makeKeyPEM returns a PKCS#1-encoded RSA private key PEM.
+func makeKeyPEM(t *testing.T) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}), key
+}
+
+// makeCSRPEM returns a CSR PEM signed by key with the given Subject fields.
+func makeCSRPEM(t *testing.T, key *rsa.PrivateKey, subject pkix.Name) []byte {
+	t.Helper()
+	tmpl := x509.CertificateRequest{Subject: subject}
+	der, err := x509.CreateCertificateRequest(rand.Reader, &tmpl, key)
+	if err != nil {
+		t.Fatalf("CreateCertificateRequest: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+}
+
+func newSchemeWithCSR(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := certv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("certv1 scheme: %v", err)
+	}
+	return scheme
+}
+
+// TestGetOrCreateCSR_ReplacesAttackerPreplantedCSR is the regression guard for
+// issue #114: an attacker with `create` on CSRs pre-plants a CSR under the
+// operator's deterministic name, bound to an attacker-controlled key, hoping
+// the operator will find it, auto-approve it, and hand back a signed cert that
+// authenticates to the API server as the target user. The pre-fix
+// getOrCreateCSR returned any pre-existing CSR unchecked; this test enforces
+// the "validate against operator key, delete-and-recreate on mismatch" contract.
+func TestGetOrCreateCSR_ReplacesAttackerPreplantedCSR(t *testing.T) {
+	scheme := newSchemeWithCSR(t)
+
+	// Operator's stored private key.
+	operatorKeyPEM, operatorKey := makeKeyPEM(t)
+	// Attacker's key, used to sign a CSR under the operator's expected name.
+	_, attackerKey := makeKeyPEM(t)
+
+	const (
+		username   = "valid-user"
+		csrName    = "valid-user-csr"
+		signerName = certv1.KubeAPIServerClientSignerName
+	)
+
+	attackerCSRPEM := makeCSRPEM(t, attackerKey, pkix.Name{CommonName: username})
+	preplanted := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   csrName,
+			Labels: map[string]string{authv1alpha1.UserLabel: username},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			Request:    attackerCSRPEM,
+			Usages:     []certv1.KeyUsage{certv1.UsageClientAuth},
+			SignerName: signerName,
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(preplanted).Build()
+
+	operatorCSRPEM := makeCSRPEM(t, operatorKey, pkix.Name{CommonName: username})
+	got, err := getOrCreateCSR(context.Background(), cli, csrName, username, operatorCSRPEM, operatorKeyPEM, time.Hour, signerName)
+	if err != nil {
+		t.Fatalf("getOrCreateCSR: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil (indicating the attacker CSR was deleted and a fresh one created for requeue), got a returned CSR — attacker CSR was reused, this is the #114 impersonation bug")
+	}
+
+	// Verify the CSR now stored under the deterministic name is bound to the
+	// operator's key, not the attacker's.
+	stored := &certv1.CertificateSigningRequest{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Name: csrName}, stored); err != nil {
+		t.Fatalf("get replacement CSR: %v", err)
+	}
+	block, _ := pem.Decode(stored.Spec.Request)
+	if block == nil {
+		t.Fatalf("replacement CSR has invalid PEM")
+	}
+	req, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse replacement CSR: %v", err)
+	}
+	pub, ok := req.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("unexpected replacement CSR key type %T", req.PublicKey)
+	}
+	if pub.Equal(&attackerKey.PublicKey) {
+		t.Fatalf("replacement CSR is bound to the attacker's public key — #114 regression")
+	}
+	if !pub.Equal(&operatorKey.PublicKey) {
+		t.Fatalf("replacement CSR is not bound to the operator's public key")
+	}
+}
+
+// TestApproveCSR_RefusesCSRThatDoesNotMatchOperatorKey is the second-line
+// defence against #114: even if a pre-planted attacker CSR slips past
+// getOrCreateCSR (e.g. via a race), the approver itself must refuse to sign
+// anything whose public key does not match the operator-held private key.
+func TestApproveCSR_RefusesCSRThatDoesNotMatchOperatorKey(t *testing.T) {
+	scheme := newSchemeWithCSR(t)
+
+	operatorKeyPEM, _ := makeKeyPEM(t)
+	_, attackerKey := makeKeyPEM(t)
+
+	const (
+		username   = "valid-user"
+		csrName    = "valid-user-csr"
+		signerName = certv1.KubeAPIServerClientSignerName
+	)
+
+	attackerCSR := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   csrName,
+			Labels: map[string]string{authv1alpha1.UserLabel: username},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			Request:    makeCSRPEM(t, attackerKey, pkix.Name{CommonName: username}),
+			Usages:     []certv1.KeyUsage{certv1.UsageClientAuth},
+			SignerName: signerName,
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(attackerCSR).Build()
+
+	err := approveCSR(context.Background(), cli, attackerCSR, csrName, username, operatorKeyPEM, signerName)
+	if err == nil {
+		t.Fatalf("approveCSR accepted an attacker CSR — #114 regression (approver signed a request whose key was not the operator's)")
+	}
+	if !strings.Contains(err.Error(), "public key") {
+		t.Fatalf("expected error to reference public-key mismatch, got: %v", err)
+	}
+}
+
+// TestApproveCSR_RefusesUnexpectedSubjectOrganization guards the group-injection
+// vector: an attacker CSR carrying Subject.Organization becomes the Groups
+// claim on the issued cert. The operator never sets one, so any non-empty
+// Organization must be rejected.
+func TestApproveCSR_RefusesUnexpectedSubjectOrganization(t *testing.T) {
+	scheme := newSchemeWithCSR(t)
+
+	operatorKeyPEM, operatorKey := makeKeyPEM(t)
+
+	const (
+		username   = "valid-user"
+		csrName    = "valid-user-csr"
+		signerName = certv1.KubeAPIServerClientSignerName
+	)
+
+	// CSR signed by the operator's own key but carrying a group claim.
+	orgCSR := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   csrName,
+			Labels: map[string]string{authv1alpha1.UserLabel: username},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			Request:    makeCSRPEM(t, operatorKey, pkix.Name{CommonName: username, Organization: []string{"sudoers"}}),
+			Usages:     []certv1.KeyUsage{certv1.UsageClientAuth},
+			SignerName: signerName,
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(orgCSR).Build()
+
+	err := approveCSR(context.Background(), cli, orgCSR, csrName, username, operatorKeyPEM, signerName)
+	if err == nil {
+		t.Fatalf("approveCSR accepted a CSR carrying Subject.Organization — attacker group-injection would be signed")
+	}
+	if !strings.Contains(err.Error(), "Organization") {
+		t.Fatalf("expected error to reference Subject.Organization, got: %v", err)
+	}
+}

--- a/internal/controller/helpers/csr.go
+++ b/internal/controller/helpers/csr.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package helpers
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+// VerifyCSRMatchesKey confirms that csrPEM was generated from keyPEM by
+// comparing the RSA public keys. This is the anti-impersonation check: any
+// pre-existing CSR under the operator's deterministic name whose public key
+// does not match the operator's stored private key must be discarded before
+// approval — otherwise an attacker with `create` on CSRs could pre-plant a
+// request under our name and receive a signed cert bound to their own key.
+func VerifyCSRMatchesKey(csrPEM, keyPEM []byte) error {
+	csrBlock, _ := pem.Decode(csrPEM)
+	if csrBlock == nil || csrBlock.Type != "CERTIFICATE REQUEST" {
+		return errors.New("invalid CSR PEM")
+	}
+	csrReq, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse CSR: %w", err)
+	}
+	csrPub, ok := csrReq.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("unexpected CSR public key type %T (want *rsa.PublicKey)", csrReq.PublicKey)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return errors.New("invalid private key PEM")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse private key: %w", err)
+	}
+
+	if !csrPub.Equal(&key.PublicKey) {
+		return errors.New("CSR public key does not match operator-held private key")
+	}
+	return nil
+}

--- a/internal/controller/renewal/csr_security_test.go
+++ b/internal/controller/renewal/csr_security_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package renewal
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	authv1alpha1 "github.com/openkube-hub/KubeUser/api/v1alpha1"
+	certv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func genKeyPEM(t *testing.T) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}), key
+}
+
+func genCSRPEM(t *testing.T, key *rsa.PrivateKey, cn string, org []string) []byte {
+	t.Helper()
+	tmpl := x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: cn, Organization: org},
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, &tmpl, key)
+	if err != nil {
+		t.Fatalf("CreateCertificateRequest: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+}
+
+// TestValidateCSRForApproval_RejectsKeyMismatch is the regression guard for
+// issue #114 on the renewal path. The pre-fix validator inspected signer,
+// usages, labels, and CN, but never verified that the CSR's public key came
+// from the operator's shadow-secret key. A CSR that satisfies every metadata
+// check but is signed with an attacker's key must be rejected.
+func TestValidateCSRForApproval_RejectsKeyMismatch(t *testing.T) {
+	rm := NewRotationManager(nil, nil, certv1.KubeAPIServerClientSignerName, "", nil)
+
+	operatorKeyPEM, _ := genKeyPEM(t)
+	_, attackerKey := genKeyPEM(t)
+
+	csr := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alice-renewal-12345678",
+			Labels: map[string]string{
+				authv1alpha1.UserLabel:     "alice",
+				authv1alpha1.RenewalLabel:  "true",
+				authv1alpha1.RotationLabel: "true",
+			},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: certv1.KubeAPIServerClientSignerName,
+			Usages:     []certv1.KeyUsage{certv1.UsageClientAuth},
+			Request:    genCSRPEM(t, attackerKey, "alice", nil),
+		},
+	}
+
+	err := rm.validateCSRForApproval(csr, "alice", operatorKeyPEM)
+	if err == nil {
+		t.Fatalf("validateCSRForApproval accepted a CSR whose public key differs from the operator-held key — #114 regression (attacker can impersonate any managed user)")
+	}
+	if !strings.Contains(err.Error(), "public key") {
+		t.Fatalf("expected error to reference public-key mismatch, got: %v", err)
+	}
+}
+
+// TestValidateCSRForApproval_RejectsSubjectOrganization guards the
+// group-injection vector: Subject.Organization becomes the Groups claim on the
+// issued cert, and the operator never sets one, so any value is an attacker's
+// attempt at privilege escalation.
+func TestValidateCSRForApproval_RejectsSubjectOrganization(t *testing.T) {
+	rm := NewRotationManager(nil, nil, certv1.KubeAPIServerClientSignerName, "", nil)
+
+	operatorKeyPEM, operatorKey := genKeyPEM(t)
+
+	csr := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alice-renewal-12345678",
+			Labels: map[string]string{
+				authv1alpha1.UserLabel:     "alice",
+				authv1alpha1.RenewalLabel:  "true",
+				authv1alpha1.RotationLabel: "true",
+			},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: certv1.KubeAPIServerClientSignerName,
+			Usages:     []certv1.KeyUsage{certv1.UsageClientAuth},
+			Request:    genCSRPEM(t, operatorKey, "alice", []string{"sudoers"}),
+		},
+	}
+
+	err := rm.validateCSRForApproval(csr, "alice", operatorKeyPEM)
+	if err == nil {
+		t.Fatalf("validateCSRForApproval accepted a CSR carrying Subject.Organization — attacker group-injection")
+	}
+	if !strings.Contains(err.Error(), "Organization") {
+		t.Fatalf("expected error to reference Subject.Organization, got: %v", err)
+	}
+}
+
+// TestValidateCSRForApproval_UsesCallerSuppliedUsernameNotLabels pins the
+// invariant that the "expected" user comes from the operator's caller, not
+// from CSR labels the attacker controls. Pre-fix the validator derived the
+// expected username from csr.Labels[UserLabel], which an attacker who pre-plants
+// a CSR trivially controls.
+func TestValidateCSRForApproval_UsesCallerSuppliedUsernameNotLabels(t *testing.T) {
+	rm := NewRotationManager(nil, nil, certv1.KubeAPIServerClientSignerName, "", nil)
+
+	operatorKeyPEM, operatorKey := genKeyPEM(t)
+
+	// CSR whose labels claim "victim" but whose Subject.CommonName is "victim"
+	// — the operator is actually rotating "someone-else", so the CN check
+	// against the caller-supplied username must fail even though labels agree
+	// with the CSR.
+	csr := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "someone-else-renewal-12345678",
+			Labels: map[string]string{
+				authv1alpha1.UserLabel:     "victim",
+				authv1alpha1.RenewalLabel:  "true",
+				authv1alpha1.RotationLabel: "true",
+			},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: certv1.KubeAPIServerClientSignerName,
+			Usages:     []certv1.KeyUsage{certv1.UsageClientAuth},
+			Request:    genCSRPEM(t, operatorKey, "victim", nil),
+		},
+	}
+
+	err := rm.validateCSRForApproval(csr, "someone-else", operatorKeyPEM)
+	if err == nil {
+		t.Fatalf("validateCSRForApproval trusted CSR-supplied labels for expected username instead of the caller's — attacker relabels the pre-planted CSR to whatever passes the CN check")
+	}
+	if !strings.Contains(err.Error(), "common name") {
+		t.Fatalf("expected error to reference CN mismatch, got: %v", err)
+	}
+}
+
+// TestEnsureCSRExists_ReplacesAttackerPreplantedCSR exercises the full "found
+// existing CSR" branch of the renewal path with a fake client and asserts the
+// pre-planted attacker CSR is deleted and replaced with one bound to the
+// shadow-secret key.
+func TestEnsureCSRExists_ReplacesAttackerPreplantedCSR(t *testing.T) {
+	t.Setenv("KUBEUSER_NAMESPACE", "kubeuser")
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+	if err := certv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("certv1 scheme: %v", err)
+	}
+
+	operatorKeyPEM, operatorKey := genKeyPEM(t)
+	_, attackerKey := genKeyPEM(t)
+
+	const (
+		username = "valid-user"
+	)
+
+	user := &authv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: username, UID: "a287d57b-1234-1234-1234-123456789012"},
+	}
+
+	rm := NewRotationManager(nil, nil, certv1.KubeAPIServerClientSignerName, "", nil)
+	csrName := rm.generateUniqueCSRName(user.Name, string(user.UID))
+
+	// Attacker pre-plants a CSR that satisfies every metadata check the
+	// pre-fix validator ran (signer, usages, labels, CN) but is signed with
+	// their own key.
+	preplanted := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: csrName,
+			Labels: map[string]string{
+				authv1alpha1.UserLabel:     username,
+				authv1alpha1.RenewalLabel:  "true",
+				authv1alpha1.RotationLabel: "true",
+			},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: certv1.KubeAPIServerClientSignerName,
+			Usages:     []certv1.KeyUsage{certv1.UsageClientAuth},
+			Request:    genCSRPEM(t, attackerKey, username, nil),
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(preplanted).Build()
+	rm.client = cli
+
+	if _, err := rm.ensureCSRExists(context.Background(), user, csrName, username, operatorKeyPEM, time.Hour); err != nil {
+		t.Fatalf("ensureCSRExists: %v", err)
+	}
+
+	stored := &certv1.CertificateSigningRequest{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Name: csrName}, stored); err != nil {
+		t.Fatalf("get replacement CSR: %v", err)
+	}
+	block, _ := pem.Decode(stored.Spec.Request)
+	if block == nil {
+		t.Fatalf("replacement CSR has invalid PEM")
+	}
+	req, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse replacement CSR: %v", err)
+	}
+	pub, ok := req.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("unexpected replacement CSR key type %T", req.PublicKey)
+	}
+	if pub.Equal(&attackerKey.PublicKey) {
+		t.Fatalf("replacement CSR is still bound to the attacker's public key — #114 regression")
+	}
+	if !pub.Equal(&operatorKey.PublicKey) {
+		t.Fatalf("replacement CSR is not bound to the operator's public key")
+	}
+}

--- a/internal/controller/renewal/rotation.go
+++ b/internal/controller/renewal/rotation.go
@@ -215,7 +215,7 @@ func (rm *RotationManager) continueRotationFromShadow(ctx context.Context, user 
 	}
 
 	// Step 3: Check CSR status and approve if needed
-	approved, signedCert, err := rm.ensureCSRApprovedAndGetCert(ctx, csrName)
+	approved, signedCert, err := rm.ensureCSRApprovedAndGetCert(ctx, csrName, username, keyPEM)
 	if err != nil {
 		rm.eventRecorder.Event(user, "Warning", "CSRApprovalFailed", fmt.Sprintf("Failed to approve CSR %s: %v", csrName, err))
 		if rm.metrics != nil {
@@ -423,7 +423,11 @@ func (rm *RotationManager) deleteShadowSecret(ctx context.Context, username stri
 	return nil
 }
 
-// ensureCSRExists creates CSR if it doesn't exist, returns existing one otherwise
+// ensureCSRExists creates CSR if it doesn't exist, returns existing one otherwise.
+// A pre-existing CSR under this deterministic name is validated against the
+// shadow-secret key before reuse; a mismatch (attacker-planted CSR under our
+// name — see #114) triggers delete-and-recreate so the operator only ever
+// signs a request bound to its own key.
 func (rm *RotationManager) ensureCSRExists(ctx context.Context, user *authv1alpha1.User, csrName, username string, keyPEM []byte, certDuration time.Duration) (*certv1.CertificateSigningRequest, error) {
 	logger := logf.FromContext(ctx)
 
@@ -431,11 +435,17 @@ func (rm *RotationManager) ensureCSRExists(ctx context.Context, user *authv1alph
 	var existingCSR certv1.CertificateSigningRequest
 	err := rm.client.Get(ctx, types.NamespacedName{Name: csrName}, &existingCSR)
 	if err == nil {
-		logger.Info("Found existing CSR", "csrName", csrName)
-		return &existingCSR, nil
-	}
-
-	if !apierrors.IsNotFound(err) {
+		if valErr := rm.validateCSRForApproval(&existingCSR, username, keyPEM); valErr != nil {
+			logger.Info("Existing CSR failed operator validation, replacing", "csrName", csrName, "reason", valErr.Error())
+			if delErr := rm.client.Delete(ctx, &existingCSR); delErr != nil && !apierrors.IsNotFound(delErr) {
+				return nil, fmt.Errorf("failed to delete untrusted CSR %s: %w", csrName, delErr)
+			}
+			// Fall through to recreate a CSR bound to the shadow-secret key.
+		} else {
+			logger.Info("Found existing CSR", "csrName", csrName)
+			return &existingCSR, nil
+		}
+	} else if !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to check for existing CSR: %w", err)
 	}
 
@@ -485,7 +495,7 @@ func (rm *RotationManager) ensureCSRExists(ctx context.Context, user *authv1alph
 }
 
 // ensureCSRApproved approves the CSR if not already approved
-func (rm *RotationManager) ensureCSRApproved(ctx context.Context, csr *certv1.CertificateSigningRequest) (bool, error) {
+func (rm *RotationManager) ensureCSRApproved(ctx context.Context, csr *certv1.CertificateSigningRequest, expectedUsername string, expectedKeyPEM []byte) (bool, error) {
 	logger := logf.FromContext(ctx)
 
 	// Check if already approved
@@ -499,7 +509,7 @@ func (rm *RotationManager) ensureCSRApproved(ctx context.Context, csr *certv1.Ce
 	}
 
 	// Validate CSR before approval for security
-	if err := rm.validateCSRForApproval(csr); err != nil {
+	if err := rm.validateCSRForApproval(csr, expectedUsername, expectedKeyPEM); err != nil {
 		logger.Error(err, "CSR validation failed", "csrName", csr.Name)
 		return false, fmt.Errorf("CSR validation failed: %w", err)
 	}
@@ -537,7 +547,7 @@ func (rm *RotationManager) ensureCSRApproved(ctx context.Context, csr *certv1.Ce
 }
 
 // ensureCSRApprovedAndGetCert checks CSR status, approves if needed, and returns signed certificate
-func (rm *RotationManager) ensureCSRApprovedAndGetCert(ctx context.Context, csrName string) (bool, []byte, error) {
+func (rm *RotationManager) ensureCSRApprovedAndGetCert(ctx context.Context, csrName, expectedUsername string, expectedKeyPEM []byte) (bool, []byte, error) {
 	logger := logf.FromContext(ctx)
 
 	// Get the CSR
@@ -561,7 +571,7 @@ func (rm *RotationManager) ensureCSRApprovedAndGetCert(ctx context.Context, csrN
 
 	// If not approved, approve it
 	if !approved {
-		_, err := rm.ensureCSRApproved(ctx, csr)
+		_, err := rm.ensureCSRApproved(ctx, csr, expectedUsername, expectedKeyPEM)
 		if err != nil {
 			return false, nil, err
 		}
@@ -884,8 +894,12 @@ func (rm *RotationManager) extractCertificateExpiry(certData []byte) (time.Time,
 	return certs.ExtractCertificateExpiryWithFormatDetection(certData)
 }
 
-// validateCSRForApproval validates a CSR before auto-approval for security
-func (rm *RotationManager) validateCSRForApproval(csr *certv1.CertificateSigningRequest) error {
+// validateCSRForApproval validates a CSR before auto-approval for security.
+// expectedUsername and expectedKeyPEM come from the caller (the shadow secret's
+// key and the User the operator is rotating), not from the CSR itself — a CSR
+// pre-planted by an attacker under the deterministic name would otherwise be
+// self-attesting and pass the CN/label checks trivially (see #114).
+func (rm *RotationManager) validateCSRForApproval(csr *certv1.CertificateSigningRequest, expectedUsername string, expectedKeyPEM []byte) error {
 	// Validate signer name matches configured signer (supports managed K8s)
 	if csr.Spec.SignerName != rm.signerName {
 		return fmt.Errorf("invalid signer name: %s (expected: %s)", csr.Spec.SignerName, rm.signerName)
@@ -927,10 +941,23 @@ func (rm *RotationManager) validateCSRForApproval(csr *certv1.CertificateSigning
 		return fmt.Errorf("failed to parse CSR: %w", err)
 	}
 
-	// Validate common name matches expected user
-	expectedUsername := csr.Labels[authv1alpha1.UserLabel]
+	// Validate common name matches the user the operator is rotating.
 	if csrReq.Subject.CommonName != expectedUsername {
 		return fmt.Errorf("CSR common name %s doesn't match expected user %s", csrReq.Subject.CommonName, expectedUsername)
+	}
+
+	// Subject.Organization becomes the Groups claim on the issued cert; the
+	// operator never sets one, so any value here is an attempted group injection.
+	if len(csrReq.Subject.Organization) > 0 {
+		return fmt.Errorf("CSR Subject.Organization %v is not permitted (operator never sets groups)", csrReq.Subject.Organization)
+	}
+
+	// Anti-impersonation: the CSR's public key must match the operator-held
+	// private key. Without this, an attacker with `create` on CSRs can pre-plant
+	// a request under the deterministic name and receive a signed cert bound to
+	// their own key.
+	if err := helpers.VerifyCSRMatchesKey(csr.Spec.Request, expectedKeyPEM); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/controller/renewal/rotation_test.go
+++ b/internal/controller/renewal/rotation_test.go
@@ -405,7 +405,7 @@ func TestRotationManager_validateCSRForApproval(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := rm.validateCSRForApproval(tt.csr)
+			err := rm.validateCSRForApproval(tt.csr, "alice", nil)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateCSRForApproval() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
## Summary

Fixes #114.

Both cert-issuance paths — `certs.getOrCreateCSR` (initial) and `rotation.ensureCSRExists` (renewal) — looked up the CSR by a deterministic name and returned whatever object sat there, unchecked. The renewal approver validated CSR structure (signer, usages, labels, CN); the initial-issuance approver did nothing. Neither verified that the CSR's public key came from the operator-held private key.

**Blast radius (pre-fix):** any principal with cluster-scoped `create` on `certificatesigningrequests` (and `get` to read the resulting cert) — but crucially not `approve` — could pre-plant a CSR under a target user's deterministic name with an attacker-controlled key and `Subject.CN=<target-user>`. The operator found the pre-planted CSR, auto-approved it via the `approval` subresource, and the signer issued a cert bound to the attacker's public key. `kubectl auth whoami` under the attacker kubeconfig then returned the target username with the target's RBAC. The exploit also left the legitimate user's kubeconfig secret containing a cert/key mismatch (DoS side-effect on the impersonated user). K8s ≥ v1.29 blocks `Subject.O=system:masters` on the `kube-apiserver-client` signer at admission time, but every other privileged group and every custom signer remains in scope.

**What the change does.** A new shared helper `helpers.VerifyCSRMatchesKey` decodes a CSR and a private key and compares RSA public keys. Both paths now:

- On finding a pre-existing CSR under the deterministic name, validate it against the operator's stored key and expected spec (signer, ClientAuth-only usages, `CommonName`, empty `Subject.Organization`, key match). On any mismatch, delete-and-recreate rather than reuse.
- Both approvers run the same gate before the `approval` subresource write. `validateCSRForApproval` now takes `expectedUsername` and `expectedKeyPEM` from the caller (the shadow secret's key on the renewal path) — pre-fix it derived the expected username from `csr.Labels[UserLabel]`, which an attacker who pre-plants a CSR trivially controls.
- Reject non-empty `Subject.Organization`. The operator never sets one; any value here becomes the `Groups` claim on the issued cert (attempted group injection).

Pattern matches the existing structural checks in `rotation.validateCSRForApproval` — the fix extends that gate rather than introducing a new mechanism.

### Regression coverage

- `internal/controller/certs/csr_security_test.go` — `TestGetOrCreateCSR_ReplacesAttackerPreplantedCSR`, `TestApproveCSR_RefusesCSRThatDoesNotMatchOperatorKey`, `TestApproveCSR_RefusesUnexpectedSubjectOrganization`.
- `internal/controller/renewal/csr_security_test.go` — `TestValidateCSRForApproval_RejectsKeyMismatch`, `TestValidateCSRForApproval_RejectsSubjectOrganization`, `TestValidateCSRForApproval_UsesCallerSuppliedUsernameNotLabels`, `TestEnsureCSRExists_ReplacesAttackerPreplantedCSR`.

Each test names the underlying bug in its failure assertion. Verified they fail on reverted production code and pass on the fixed code.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `make lint` — 0 issues
- [x] New unit tests fail without the fix, pass with it (verified by reverting the semantic checks and re-running)
- [x] Live-verified on local kind (v1.35.0) running a built image of this branch. Reproduced the #114 exploit step-for-step against `valid-user`: pre-planted a CSR at `valid-user-renewal-<uid8>` with an attacker RSA key and `Subject.CN=valid-user`, then triggered rotation via `spec.auth.ttl` patch. Controller logged `"Existing CSR failed operator validation, replacing" reason:"CSR public key does not match operator-held private key"`, deleted the attacker CSR, recreated one bound to its own key, and issued a cert whose public key matches the operator's key (md5 confirmed). `kubectl auth whoami` with the attacker's key + the issued cert failed at TLS handshake (`private key does not match public key`); the legitimate `valid-user-kubeconfig` still authenticated as `valid-user` and could `get pods -A` under the `view` ClusterRole.
- [ ] Reviewer: consider whether we also want a per-attempt random suffix on the initial-issuance CSR name (`<user>-csr` is fully guessable from `list users`) as defence in depth. Left out of this PR to keep scope to the primary fix.