### PR TITLE
fix(webhook): make mutating webhook Ignore, add controller PDB, split Helm keys

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- pdb.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/pdb.yaml
+++ b/config/manager/pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: kubeuser
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: kubeuser

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,7 +11,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-auth-openkube-io-v1alpha1-user
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: muser.auth.openkube.io
   rules:
   - apiGroups:

--- a/helm/kubeuser/README.md
+++ b/helm/kubeuser/README.md
@@ -115,6 +115,11 @@ The following table lists the configurable parameters and their default values:
 | `resources.requests.memory` | Memory request | `64Mi` |
 | `webhook.enabled` | Enable webhook server | `true` |
 | `webhook.service.port` | Webhook service port | `443` |
+| `webhook.mutating.failurePolicy` | Mutating webhook failure policy. Defaults are re-applied by the controller on every reconcile, so `Ignore` avoids turning a webhook-pod restart into a cluster-wide User create/update outage. Setting this to `Fail` reintroduces issue #38. | `Ignore` |
+| `webhook.validating.failurePolicy` | Validating webhook failure policy. Enforces mandatory `spec.auth.type`, reserved-identity prefix, RBAC-reference existence, and TTL/renewBefore bounds. Setting this to `Ignore` admits Users the controller cannot safely reconcile. | `Fail` |
+| `podDisruptionBudget.enabled` | Create a PodDisruptionBudget for the controller pod that serves the webhooks. | `true` |
+| `podDisruptionBudget.minAvailable` | Minimum controller replicas that must stay available during voluntary disruption. Set to `null` if using `maxUnavailable` instead. | `1` |
+| `podDisruptionBudget.maxUnavailable` | Maximum controller replicas that may be unavailable during voluntary disruption. Mutually exclusive with `minAvailable`. | `null` |
 | `metrics.enabled` | Enable metrics endpoint | `true` |
 | `metrics.service.port` | Metrics service port | `8080` |
 | `rbac.create` | Create RBAC resources | `true` |

--- a/helm/kubeuser/templates/_helpers.tpl
+++ b/helm/kubeuser/templates/_helpers.tpl
@@ -92,6 +92,19 @@ Create image name
 {{- end }}
 
 {{/*
+Reject the pre-#38 single webhook.failurePolicy key. The chart now sets
+mutating and validating policies independently (Ignore / Fail); a shared
+key silently pushes the mutating webhook back to Fail and reintroduces the
+outage. Called from templates/webhook-csr.yaml so users see the error
+before the chart tries to render with an unexpected default.
+*/}}
+{{- define "kubeuser.validateWebhookFailurePolicy" -}}
+{{- if hasKey .Values.webhook "failurePolicy" -}}
+{{- fail "webhook.failurePolicy was removed. Set webhook.mutating.failurePolicy (default Ignore) and webhook.validating.failurePolicy (default Fail) separately. A single shared value would revert the fix for issue #38." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate that terminationGracePeriodSeconds leaves at least 5 seconds of
 headroom above manager.gracefulShutdownTimeoutSeconds. Headroom covers the
 leader-lease release PATCH and any straggling API calls on the way out.

--- a/helm/kubeuser/templates/pdb.yaml
+++ b/helm/kubeuser/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kubeuser.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeuser.managerLabels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kubeuser.managerSelectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/kubeuser/templates/webhook-csr.yaml
+++ b/helm/kubeuser/templates/webhook-csr.yaml
@@ -1,3 +1,4 @@
+{{- include "kubeuser.validateWebhookFailurePolicy" . -}}
 {{- if .Values.webhook.enabled }}
 ---
 # MutatingWebhookConfiguration with cert-manager CA injection
@@ -19,7 +20,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /mutate-auth-openkube-io-v1alpha1-user
     # caBundle will be injected automatically by cert-manager
-  failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}
+  failurePolicy: {{ .Values.webhook.mutating.failurePolicy | default "Ignore" }}
   name: muser.auth.openkube.io
   rules:
   - apiGroups:
@@ -52,7 +53,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /validate-auth-openkube-io-v1alpha1-user
     # caBundle will be injected automatically by cert-manager
-  failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}
+  failurePolicy: {{ .Values.webhook.validating.failurePolicy | default "Fail" }}
   name: vuser.auth.openkube.io
   rules:
   - apiGroups:

--- a/helm/kubeuser/values.yaml
+++ b/helm/kubeuser/values.yaml
@@ -48,6 +48,18 @@ securityContext:
 # Deployment configuration
 replicaCount: 2
 
+# PodDisruptionBudget for the controller pod that serves the webhooks.
+# minAvailable: 1 makes voluntary disruptions (node drains, cluster
+# upgrades) block on a replacement pod becoming Ready instead of taking
+# the validating webhook offline mid-drain. Set enabled: false in
+# single-replica dev clusters where you'd rather let drains proceed.
+# Set only one of minAvailable / maxUnavailable — the template picks
+# whichever is non-null.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  maxUnavailable: null
+
 # kubelet's SIGTERM→SIGKILL window. Must exceed manager.gracefulShutdownTimeoutSeconds
 # by at least 5s of headroom for the leader-lease release PATCH.
 # Chart validation in _helpers.tpl enforces this on every install/upgrade.
@@ -97,9 +109,24 @@ manager:
 webhook:
   enabled: true
   certPath: /tmp/k8s-webhook-server/serving-certs
-  # Fail = block requests if webhook fails (production)
-  # Ignore = allow requests if webhook fails (for testing)
-  failurePolicy: Fail
+  # Per-webhook failure policies. These are correctness invariants, not
+  # operational preferences — the defaults below are the safe ones.
+  #
+  # mutating: Ignore. The mutating webhook only writes TTL / autoRenew
+  #   defaults, and the controller re-derives the exact same values via
+  #   auth.GetSafeAuthSpec on every reconcile. Setting this to Fail turns
+  #   any webhook-pod restart, node drain, or rolling upgrade into a
+  #   cluster-wide User create/update outage (see issue #38).
+  #
+  # validating: Fail. The validating webhook is the only enforcement point
+  #   for mandatory spec.auth.type, the "system:" reserved-identity prefix,
+  #   Role/ClusterRole reference existence, and TTL/renewBefore bounds.
+  #   Setting this to Ignore admits Users that the controller cannot
+  #   safely reconcile.
+  mutating:
+    failurePolicy: Ignore
+  validating:
+    failurePolicy: Fail
   # cert-manager configuration for webhook certificates
   certManager:
     # Duration for webhook certificates

--- a/internal/webhook/user_webhook.go
+++ b/internal/webhook/user_webhook.go
@@ -29,7 +29,7 @@ type UserWebhook struct {
 	client.Client
 }
 
-// +kubebuilder:webhook:path=/mutate-auth-openkube-io-v1alpha1-user,mutating=true,failurePolicy=fail,sideEffects=None,groups=auth.openkube.io,resources=users,verbs=create;update,versions=v1alpha1,name=muser.auth.openkube.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-auth-openkube-io-v1alpha1-user,mutating=true,failurePolicy=ignore,sideEffects=None,groups=auth.openkube.io,resources=users,verbs=create;update,versions=v1alpha1,name=muser.auth.openkube.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validate-auth-openkube-io-v1alpha1-user,mutating=false,failurePolicy=fail,sideEffects=None,groups=auth.openkube.io,resources=users,verbs=create;update,versions=v1alpha1,name=vuser.auth.openkube.io,admissionReviewVersions=v1
 
 // SetupWithManager registers the webhook with the manager

--- a/internal/webhook/webhook_manifests_test.go
+++ b/internal/webhook/webhook_manifests_test.go
@@ -1,0 +1,94 @@
+package webhook
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// TestWebhookFailurePolicies pins the availability contract from issue #38:
+// the mutating webhook must tolerate its own outage (Ignore) because the
+// controller re-applies the same defaults via auth.GetSafeAuthSpec on every
+// reconcile, while the validating webhook enforces security-critical guards
+// (mandatory auth.type, reserved-identity prefix, RBAC-reference existence,
+// renewBefore bounds) and must remain Fail. A silent flip of either policy
+// would either mask invalid Users past admission or turn a webhook pod
+// restart into a cluster-wide User create/update outage.
+func TestWebhookFailurePolicies(t *testing.T) {
+	path := filepath.Join("..", "..", "config", "webhook", "manifests.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var (
+		mutating   *admissionregistrationv1.MutatingWebhookConfiguration
+		validating *admissionregistrationv1.ValidatingWebhookConfiguration
+	)
+
+	for _, doc := range splitYAMLDocs(string(data)) {
+		var meta struct {
+			Kind string `json:"kind"`
+		}
+		if err := yaml.Unmarshal([]byte(doc), &meta); err != nil {
+			t.Fatalf("decode kind: %v", err)
+		}
+		switch meta.Kind {
+		case "MutatingWebhookConfiguration":
+			mutating = &admissionregistrationv1.MutatingWebhookConfiguration{}
+			if err := yaml.Unmarshal([]byte(doc), mutating); err != nil {
+				t.Fatalf("decode mutating: %v", err)
+			}
+		case "ValidatingWebhookConfiguration":
+			validating = &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			if err := yaml.Unmarshal([]byte(doc), validating); err != nil {
+				t.Fatalf("decode validating: %v", err)
+			}
+		}
+	}
+
+	if mutating == nil {
+		t.Fatal("MutatingWebhookConfiguration not found in manifests.yaml")
+	}
+	if validating == nil {
+		t.Fatal("ValidatingWebhookConfiguration not found in manifests.yaml")
+	}
+	if len(mutating.Webhooks) == 0 {
+		t.Fatal("MutatingWebhookConfiguration has no webhooks")
+	}
+	if len(validating.Webhooks) == 0 {
+		t.Fatal("ValidatingWebhookConfiguration has no webhooks")
+	}
+
+	assertFailurePolicy(t, "mutating", mutating.Webhooks[0].Name, mutating.Webhooks[0].FailurePolicy, admissionregistrationv1.Ignore,
+		"defaults are re-applied by the controller via auth.GetSafeAuthSpec; a webhook outage must not block User create/update")
+	assertFailurePolicy(t, "validating", validating.Webhooks[0].Name, validating.Webhooks[0].FailurePolicy, admissionregistrationv1.Fail,
+		"validating webhook enforces mandatory auth.type, reserved-identity rejection, RBAC-reference existence, and renewBefore bounds — bypassing it admits unsafe Users")
+}
+
+func assertFailurePolicy(t *testing.T, kind, name string, got *admissionregistrationv1.FailurePolicyType, want admissionregistrationv1.FailurePolicyType, reason string) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s webhook %q has nil failurePolicy; want %s (%s)", kind, name, want, reason)
+	}
+	if *got != want {
+		t.Fatalf("%s webhook %q failurePolicy = %s; want %s (%s)", kind, name, *got, want, reason)
+	}
+}
+
+func splitYAMLDocs(s string) []string {
+	parts := strings.Split(s, "\n---")
+	docs := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "---" {
+			continue
+		}
+		docs = append(docs, p)
+	}
+	return docs
+}


### PR DESCRIPTION
## Summary

Fixes #38.

Both webhooks shipped with `failurePolicy: Fail` and no PodDisruptionBudget on the controller pod that serves them. Because the same pod hosts both webhooks, any voluntary disruption — node drain, rolling upgrade, or the pod restart on a `replicaCount: 1` deployment — turned into a cluster-wide outage for User create/update, blocking exactly the emergency-access path an operator would reach for during an incident. The chart made this worse by exposing a single `webhook.failurePolicy` value that fanned out to both configurations, forcing operators to pick one policy for two very different guarantees.

**Kustomize/manifest layer** (`internal/webhook/user_webhook.go`, `config/webhook/manifests.yaml`, `config/manager/pdb.yaml`, `config/manager/kustomization.yaml`): flip the mutating webhook to `failurePolicy: Ignore` via the kubebuilder marker and regenerate. The mutating webhook only writes `TTL` and `AutoRenew` defaults from `auth.GetSafeAuthSpec` (`internal/webhook/user_webhook.go:70`), and the controller re-derives the same values through `GetSafeAuthSpec` on every reconcile (`internal/controller/auth/auth.go:260`), so a missed mutation is invisible at runtime — the persisted spec is missing those two fields until the next `kubectl edit`, but effective behavior is identical. The validating webhook stays at `Fail`: it enforces mandatory `spec.auth.type`, the `system:` reserved-identity prefix, Role/ClusterRole existence, and the `renewBefore`/TTL bounds (`internal/webhook/user_webhook.go:87` and `:255`), and bypassing it would admit Users that the controller cannot safely reconcile. A new `PodDisruptionBudget` (`minAvailable: 1`) protects the validating webhook during node drains.

**Helm layer** (`helm/kubeuser/`): split the shared `webhook.failurePolicy` into `webhook.mutating.failurePolicy` (default `Ignore`) and `webhook.validating.failurePolicy` (default `Fail`) as two independent knobs, delete the old shared key, and add a helm-time `validateWebhookFailurePolicy` guard that hard-fails install/upgrade if the legacy shape is still in someone's values file — the shared shape is what caused #38 in the first place, so silently accepting it would let the outage back in. Chart is pre-v1 (0.1.0), so a values rename is acceptable. Add `helm/kubeuser/templates/pdb.yaml` gated by `podDisruptionBudget.enabled` (default true; `minAvailable: 1`). With the chart's default `replicaCount: 2`, this allows exactly one disruption at a time and blocks node drains until a replacement is Ready.

### Regression coverage

`TestWebhookFailurePolicies` in `internal/webhook/webhook_manifests_test.go` parses the generated `config/webhook/manifests.yaml` and asserts `muser` is `Ignore` and `vuser` is `Fail`, with an assertion message that names the underlying invariant so the next person who flips either policy sees a clear explanation. Verified the test fails on the pre-fix manifest (`failurePolicy = Fail; want Ignore`) and passes on the fixed manifest. The helm-time `validateWebhookFailurePolicy` helper is a companion regression guard on the Helm side — `helm template ... --set webhook.failurePolicy=Fail` now returns `Error: ... webhook.failurePolicy was removed. ...`, keeping the shared shape from creeping back through values overrides.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `make lint` — 0 issues
- [x] `make manifests` re-run to confirm the kubebuilder marker regenerates cleanly
- [x] `kubectl kustomize config/default` renders the PDB and correct failure policies
- [x] `helm template helm/kubeuser` renders `mutating: Ignore`, `validating: Fail`, and the PDB
- [x] `helm template --set webhook.failurePolicy=Fail` errors out with the migration message
- [x] New unit test fails without the fix, passes with it (verified by reverting the manifest)
- [x] **Live-verified on kind (v1.34.0)** after `bash hack/setup-cluster.sh --upgrade-only`:
  - `kubectl get mutatingwebhookconfiguration` shows `Ignore`, validating shows `Fail`, PDB reports `ALLOWED DISRUPTIONS: 1`.
  - Patched mutating webhook's `clientConfig.service.port` to `9999` to simulate an unreachable mutating webhook while validating stayed healthy. Applied a minimal `User { auth.type: x509 }` with no TTL / autoRenew — accepted, persisted spec was `{"type":"x509"}` (mutation skipped), controller reconciled to `Active` with `expiryTime` exactly 90 days out (default `KUBEUSER_DEFAULT_TTL: 2160h` applied by `GetSafeAuthSpec` at reconcile).
  - In the same simulated outage, applying a User referencing a nonexistent ClusterRole was rejected by `admission webhook "vuser.auth.openkube.io" denied the request: clusterrole 'does-not-exist-xyz' not found` — validating still enforces.
  - Restored port and cleaned up test users.
- [ ] Reviewer to smoke-test a real node drain (`kubectl drain kubeuser-worker --ignore-daemonsets --delete-emptydir-data`) to confirm the PDB actually blocks eviction of the last controller replica; I did not exercise this in the single-worker kind cluster.